### PR TITLE
Switch required pydantic versioning to accomodate v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,14 @@ dependencies = [
   'distro==1.8.0',
   'elasticsearch==8.11.0',
   'jsons==1.6.3',
-  'pydantic==1.*',
+  'pydantic>=1.2',
   'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.3.8#subdirectory=crates/pyluwen',
   'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.3',
   'rich==13.7.0',
   'textual==0.59.0',
   'pre-commit==3.5.0',
   'importlib_resources==6.1.1',
+  'setuptools',
 ]
 
 [project.urls]

--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -11,9 +11,14 @@ import inspect
 import datetime
 from pathlib import Path
 from typing import Any, Union, List, TypeVar, Generic
-from pydantic import BaseModel
-from pydantic.fields import Field
-
+try:
+    # Try the newer v2 pydantic and use that first
+    from pydantic.v1 import BaseModel
+    from pydantic.v1.fields import Field
+except:
+    # Assume we are on v1 and give that a go
+    from pydantic import BaseModel
+    from pydantic.fields import Field
 
 class Long(int):
     ...


### PR DESCRIPTION
Pydantic has a ground up re-write that's starting to make it into newer distros, F40, OpenSuse Tumbleweed, etc which includes pydantic v1 support, but breaks the default importing we are doing.

This adjusts the base pydantic in pyproject.toml to be a minimum of 1.2 (to meet Ubuntu 20.04 baseline requirements) and adds a try/except block to try loading the correct pydantic version where we are expecting.

Quick check on F40, in a venv, this plus the change in tt-tools-common to do roughly the same thing should sort out #27