### PR TITLE
Allow to use --help and --version arguments without kernel driver loaded

### DIFF
--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -746,6 +746,8 @@ def main():
     # Enable backtrace for debugging
     os.environ["RUST_BACKTRACE"] = "full"
 
+    args = parse_args()
+
     driver = get_driver_version()
     if not driver:
         print(
@@ -754,8 +756,6 @@ def main():
             CMD_LINE_COLOR.ENDC,
         )
         sys.exit(1)
-
-    args = parse_args()
 
     # Handle reset first, without setting up backend or
     if args.reset is not None:


### PR DESCRIPTION
Parse command line arguments before checking for the kernel driver, so that usage and version information can be displayed also on systems where the tenstorrent.ko kernel driver module is not loaded.

Resolves tt-smi issue #44.