### PR TITLE
Consistently show L/R for all Wormhole devices

### DIFF
--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -382,7 +382,7 @@ class TTSMI(App):
             for info in constants.DEV_INFO_LIST:
                 val = self.backend.device_infos[i][info]
                 if info == "board_type":
-                    if val == "n300":
+                    if device.as_wh():
                         if device.is_remote():
                             rows.append(
                                 Text(


### PR DESCRIPTION
Align the conditions to check for all Wormhole devices in both `--list` mode and UI.

Resolves issue #48.