### PR TITLE
Add support for snapshot to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Dev
 
 - Specifying `tt-smi -s` now prints a snapshot to stdout, per issue 39
-- `tt-smi -f <optional filename>` now behaves like `tt-smi -s -f`
-- tt-smi now attempts to determine if the output is a tty to better support scripting (primarily no statusbars)
-- Added `--snapshot_no_tty` arg to force no-tty behavior
+    - `tt-smi -f <optional filename>` now behaves like `tt-smi -s -f`
+    - tt-smi now attempts to determine if the output is a tty to better support scripting (primarily no statusbars)
+    - Added `--snapshot_no_tty` arg to force no-tty behavior
+- Updated tt-tools-common to 1.4.10
 
 ## 3.0.4 - 11/12/2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Dev
+
+- Specifying `tt-smi -s` now prints a snapshot to stdout, per issue 39
+- `tt-smi -f <optional filename>` now behaves like `tt-smi -s -f`
+- tt-smi now attempts to determine if the output is a tty to better support scripting (primarily no statusbars)
+- Added `--snapshot_no_tty` arg to force no-tty behavior
+
 ## 3.0.4 - 11/12/2024
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   'jsons==1.6.3',
   'pydantic>=1.2',
   'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.4.8#subdirectory=crates/pyluwen',
-  'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.9',
+  'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.10',
   'rich==13.7.0',
   'textual==0.59.0',
   'pre-commit==3.5.0',

--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -22,13 +22,16 @@ except:
     from pydantic.fields import Field
 
 
-class Long(int): ...
+class Long(int):
+    ...
 
 
-class Keyword(str): ...
+class Keyword(str):
+    ...
 
 
-class Text(str): ...
+class Text(str):
+    ...
 
 
 class Date(datetime.datetime):
@@ -134,7 +137,8 @@ class ElasticModel(BaseModel):
 T = TypeVar("T", bound=ElasticModel)
 
 
-class Nested(list, Generic[T]): ...
+class Nested(list, Generic[T]):
+    ...
 
 
 class HostInfo(ElasticModel):
@@ -260,11 +264,13 @@ class TTSMILog(ElasticModel):
     host_info: HostInfo
     device_info: List[TTSMIDeviceLog]
 
-    def save_as_json(self, fname: Union[str, Path]):
-        with open(fname, "w") as f:
-            raw_json = self.json(exclude_none=True)
-            reloaded_json = json.loads(raw_json)
-            json.dump(reloaded_json, f, indent=4)
+    def get_clean_json_string(self):
+        """Returns a cleaned json string"""
+        raw_json = self.json(exclude_none=True)
+        clean_json = json.loads(raw_json)
+        json_str = json.dumps(clean_json, indent=4)
+
+        return json_str
 
 
 @optional


### PR DESCRIPTION
tt-smi -s now sends JSON to stdout, -f writes it to a file, per issue #39 

Note that this isn't currently usable with pipes, e.g.  `tt-smi -s | jq` because the backend instantiation outputs a progress bar. Some of the progress bars appear to be in tt-tools-common? Making them transient isn't a fix since that relies on terminal control characters which don't properly affect piped output. Before making far-reaching changes I wanted to open discussion of how to resolve this issue.