### PR TITLE
Export tt_smi and pyluwen versions to snapshot JSON

### DIFF
--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -152,6 +152,11 @@ class HostInfo(ElasticModel):
     Driver: str
 
 
+class HostSWVersions(ElasticModel):
+    tt_smi: str
+    pyluwen: str
+
+
 @optional
 class SmbusTelem(ElasticModel):
     BOARD_ID: str
@@ -262,6 +267,7 @@ class TTSMIDeviceLog(ElasticModel):
 class TTSMILog(ElasticModel):
     time: datetime.datetime
     host_info: HostInfo
+    host_sw_vers: HostSWVersions
     device_info: List[TTSMIDeviceLog]
 
     def get_clean_json_string(self):

--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import datetime
+import pkg_resources
 from tt_smi import log
 from pathlib import Path
 from rich.text import Text
@@ -58,6 +59,7 @@ class TTSMIBackend:
         self.log: log.TTSMILog = log.TTSMILog(
             time=datetime.datetime.now(),
             host_info=get_host_info(),
+            host_sw_vers=get_host_software_versions(),
             device_info=[
                 log.TTSMIDeviceLog(
                     smbus_telem=log.SmbusTelem(),
@@ -569,6 +571,13 @@ def dict_from_public_attrs(obj) -> dict:
     for attr in public:
         ret[attr] = getattr(obj, attr)
     return ret
+
+
+def get_host_software_versions() -> dict:
+    return {
+        "tt_smi": pkg_resources.get_distribution("tt_smi").version,
+        "pyluwen": pkg_resources.get_distribution("pyluwen").version,
+    }
 
 
 # Reset specific functions


### PR DESCRIPTION
Fixes issue #51. This is a little bit odd, architecturally, because there's a good argument for including this in HostInfo in log.py. *However*, HostInfo is generated by get_host_info() in tt_tools_common, and is also used to generate the host info sidebar box in the UI, which isn't checked by pydantic and doesn't need this version info. 

In the long term I really don't like using a function in a different library to generate data for pydantic; it's kind of the reverse of the usual flow of truth. Rather than dive into that now, however, I've just built out another top-level model/field which has the information we need. The get_host_sw_versions function could live in tt_tools_common for consistency, if we'd like.

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-5) by [Unito](https://www.unito.io)
