### PR TITLE
chore: bump pyluwen dep to 0.6.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.11 - 13/03/25
+
+- Chore - bumped luwen version to include enable chips with external connections but no routing
+
 ## 3.0.10 - 10/03/25
 
 - Chore - bumped luwen version to include protoc lib detection check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-smi"
-version = "3.0.10"
+version = "3.0.11"
 description = "ncurses based hardware monitoring for Tenstorrent silicon"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -27,7 +27,7 @@ dependencies = [
   'distro==1.8.0',
   'elasticsearch==8.11.0',
   'pydantic>=1.2',
-  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.5.0#subdirectory=crates/pyluwen',
+  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.6.2#subdirectory=crates/pyluwen',
   'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14',
   'rich==13.7.0',
   'textual==0.59.0',


### PR DESCRIPTION
chore: bump pyluwen dep to 0.6.2 to enable chips with external connections but no routing

From https://github.com/tenstorrent/luwen/pull/23/commits
