### PR TITLE
Add support for resetting all on TG

### DIFF
--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -643,6 +643,9 @@ def mobo_reset_from_json(json_dict) -> dict:
 def pci_board_reset(list_of_boards: List[int], reinit=False):
     """Given a list of PCI index's init the PCI chip and call reset on it"""
 
+    # Sanity... filter out repeats
+    list_of_boards = list(sorted(set(list_of_boards)))
+
     reset_wh_pci_idx = []
     reset_gs_devs = []
     reset_bh_pci_idx = []


### PR DESCRIPTION
I would like `tt-smi -r` to reset the entire system, no matter what the system type.

As I understand it a reset json is a requirement for TG.

To unify the command for all systems, I propose using the default reset json config path.

If there is a json file in the default path, use it automatically.

```
default_config_path = os.path.expanduser("~/.config/tenstorrent/reset_config.json")
```

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-24) by [Unito](https://www.unito.io)
