### PR TITLE
Add WH UBB reset into tt-smi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.14 - 21/04/25
+
+- Added wh ubb reset via command line `tt-smi --ubb_reset`. Intention is that this command line option will be removed and integrated into `tt-smi -r` after we update board detection with the correct external naming.
+- Removed some unused imports and code - no functional changes
+
 ## 3.0.13 - 21/03/25
 
 - Removed get\_sw\_versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   'distro==1.8.0',
   'elasticsearch==8.11.0',
   'pydantic>=1.2',
-  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.6.3#subdirectory=crates/pyluwen',
+  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.6.4#subdirectory=crates/pyluwen',
   'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14',
   'rich==13.7.0',
   'textual==0.59.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-smi"
-version = "3.0.13"
+version = "3.0.14"
 description = "ncurses based hardware monitoring for Tenstorrent silicon"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -35,6 +35,7 @@ from tt_smi.tt_smi_backend import (
     pci_board_reset,
     pci_indices_from_json,
     mobo_reset_from_json,
+    wh_ubb_reset
 )
 from tt_tools_common.utils_common.tools_utils import (
     hex_to_semver_m3_fw,
@@ -702,12 +703,17 @@ def parse_args():
         ),
         dest="reset",
     )
-
     parser.add_argument(
         "--snapshot_no_tty",
         default=False,
         action="store_true",
         help="Force no-tty behavior in the snapshot to stdout",
+    )
+    parser.add_argument(
+        "--ubb_reset",
+        default=False,
+        action="store_true",
+        help="ubb_reset",
     )
 
     args = parser.parse_args()
@@ -729,6 +735,9 @@ def tt_smi_main(backend: TTSMIBackend, args):
     signal.signal(signal.SIGINT, interrupt_handler)
     signal.signal(signal.SIGTERM, interrupt_handler)
 
+    if args.ubb_reset:
+        wh_ubb_reset()
+        sys.exit(0)
     if args.list:
         backend.print_all_available_devices()
         sys.exit(0)

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -20,7 +20,6 @@ import pkg_resources
 from rich.text import Text
 from tt_smi import constants
 from typing import List, Tuple
-from textual.reactive import reactive
 from importlib_resources import files
 from pyluwen import pci_scan
 from textual.app import App, ComposeResult
@@ -43,13 +42,11 @@ from tt_tools_common.utils_common.tools_utils import (
 )
 from tt_tools_common.utils_common.system_utils import (
     get_driver_version,
-    get_host_info,
     get_host_compatibility_info,
 )
 from tt_tools_common.ui_common.widgets import (
     TTHeader,
     TTDataTable,
-    TTMenu,
     TTHostCompatibilityMenu,
     TTHelperMenuBox,
 )
@@ -116,8 +113,6 @@ class TTSMI(App):
 
     def compose(self) -> ComposeResult:
         """Create child widgets for the app."""
-
-        board_ids = [info["board_id"] for info in self.backend.device_infos]
 
         yield TTHeader(self.app_name, self.app_version)
         with Container(id="app_grid"):

--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -14,7 +14,6 @@ import datetime
 import pkg_resources
 from tt_smi import log
 from pathlib import Path
-from rich.text import Text
 from pyluwen import PciChip
 from rich.table import Table
 from tt_smi import constants


### PR DESCRIPTION
Reset is as follows with option `tt-smi --ubb_reset`.  This option will be removed and replaced with `tt-smi -r` once we have added board_type recognition for the wh ubbs. Currently discussing with marketing what the best way to display that would be.

```
(.venv) user@ubb-system:~/tt-smi$ tt-smi --ubb_reset
 Detected Chips: 32
 Detecting ARC: \
 Detecting DRAM: \
 [] [16/16] ETH: \
Gathering Information ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
 Putting WH chip at PCI index 31 into an A3 state 
Waiting for 5 seconds: 5
 Resetting WH UBBs 
Executing command: sudo ipmitool raw 0x30 0x8B 0xF 0xFF 0x0 0xF
Waiting for 30 seconds: 30
Driver loaded
 Re-initializing boards after reset.... 
 Detected Chips: 32
 Detecting ARC: -
 Detecting DRAM: \
 [] [16/16] ETH: \
 Re-initialized 32 boards after reset. Exiting... 
```

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-28) by [Unito](https://www.unito.io)
