### PR TITLE
Patched ubb_reset to detect local only in post discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.15 - 24/04/25
+
+- Patch for the ubb_reset to just discover local only post reset. Looks like eth port status 2 has been re-used to mean connected and pyluwen waits for it to clear, leading to eth timeout.
+
 ## 3.0.14 - 21/04/25
 
 - Added wh ubb reset via command line `tt-smi --ubb_reset`. Intention is that this command line option will be removed and integrated into `tt-smi -r` after we update board detection with the correct external naming.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-smi"
-version = "3.0.14"
+version = "3.0.15"
 description = "ncurses based hardware monitoring for Tenstorrent silicon"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -774,7 +774,9 @@ def wh_ubb_reset(reinit=True):
         CMD_LINE_COLOR.ENDC,
     )
     try:
-        chips = detect_chips_with_callback()
+        # eth status 2 has been reused to denote "connected", leading to false hangs when detecting chips
+        # discover local only to fix that
+        chips = detect_chips_with_callback(local_only=True, ignore_ethernet=True)
         print(
             CMD_LINE_COLOR.GREEN,
             f"Re-initialized {len(chips)} boards after reset. Exiting...",


### PR DESCRIPTION
- Looks like eth port status 2 has been re-used to mean connected and pyluwen waits for it to clear, leading to false eth timeout.
- Patching ubb reset to detect pcie chips only post reset