### PR TITLE
Chore: smi version bump v3.0.21 -> v.3.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.22 - 02/07/25
+- Bumped tt-tools-common 1.4.16 -> 1.4.17
+- Bumped luwen 0.7.2 -> 0.7.3
+- Bumped smi 3.0.21 -> 3.0.22
+
 ## 3.0.21 - 26/06/25
 
 - Added option to not re-init chips after reset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-smi"
-version = "3.0.21"
+version = "3.0.22"
 description = "ncurses based hardware monitoring for Tenstorrent silicon"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -27,8 +27,8 @@ dependencies = [
   'distro==1.8.0',
   'elasticsearch==8.11.0',
   'pydantic>=1.2',
-  'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.16',
-  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.6.5#subdirectory=crates/pyluwen',
+  'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.17',
+  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.7.3#subdirectory=crates/pyluwen',
   'rich==13.7.0',
   'textual==0.59.0',
   'pre-commit==3.5.0',


### PR DESCRIPTION
- luwen v0.7.2 -> v0.7.3
- tools common v1.4.16 -> v1.4.17