### PR TITLE
Added option to perform tray level reset on a 6U galaxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.26 - 29/07/25
+- Added single tray galaxy reset option
+- Bumped luwen from 0.7.5 -> 0.7.10
+  - Chip detect now doesn't wait for eth to train for the 6U galaxy's, allowing multi tray resets to happen independently
+- Updated readme with the new reset option
+
+## 3.0.25 - 29/07/25
+- Added packaging
+
 ## 3.0.24 - 04/07/25
 - Now users have 2 galay reset modes available
   - glx_reset: resets the galaxy, informs users if there has been an eth failure

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ pre-commit install
 
 Command line arguments
 ```
-tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [filename]] [-g] [-r 0,1 ... or config.json]
+tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-g [GENERATE_RESET_JSON]] [-c]
+              [-r [0,1 ... or config.json ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto]
+              [-glx_reset_tray {1,2,3,4}] [--no_reinit]
 ```
 ## Getting Help!
 
@@ -73,10 +75,13 @@ Running tt-smi with the ```-h, --help``` flag should bring up something that loo
 ```
 $ tt-smi --help
 
-usage: tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-g [GENERATE_RESET_JSON]] [-c] [-r [0,1 ... or config.json ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto] [--no_reinit]
+usage: tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-g [GENERATE_RESET_JSON]] [-c]
+              [-r [0,1 ... or config.json ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto]
+              [-glx_reset_tray {1,2,3,4}] [--no_reinit]
 
-Tenstorrent System Management Interface (TT-SMI) is a command line utility to interact with all Tenstorrent devices on host. Main objective of TT-SMI is to provide a simple and easy to use
-interface to collect and display device, telemetry and firmware information. In addition user can issue Grayskull and Wormhole board level resets.
+Tenstorrent System Management Interface (TT-SMI) is a command line utility to interact with all Tenstorrent devices
+on host. Main objective of TT-SMI is to provide a simple and easy to use interface to collect and display device,
+telemetry and firmware information. In addition user can issue Grayskull and Wormhole board level resets.
 
 options:
   -h, --help            show this help message and exit
@@ -87,17 +92,21 @@ options:
   -f [snapshot filename], --filename [snapshot filename]
                         Write snapshot to a file. Default: ~/tt_smi/<timestamp>_snapshot.json
   -g [GENERATE_RESET_JSON], --generate_reset_json [GENERATE_RESET_JSON]
-                        Generate default reset json file that reset consumes. Default stored at ~/.config/tenstorrent/reset_config.json. Update the generated file and use it as an input for the
-                        --reset option
+                        Generate default reset json file that reset consumes. Default stored at
+                        ~/.config/tenstorrent/reset_config.json. Update the generated file and use it as an input
+                        for the --reset option
   -c, --compact         Run in compact mode, hiding the sidebar and other static elements
   -r [0,1 ... or config.json ...], --reset [0,1 ... or config.json ...]
-                        Provide list of PCI index or a json file with reset configs. Find PCI index of board using the -ls option. Generate a default reset json file with the -g option.
+                        Provide list of PCI index or a json file with reset configs. Find PCI index of board using
+                        the -ls option. Generate a default reset json file with the -g option.
   --snapshot_no_tty     Force no-tty behavior in the snapshot to stdout
   -glx_reset, --galaxy_6u_trays_reset
                         Reset all the asics on the galaxy host.
   -glx_reset_auto, --galaxy_6u_trays_reset_auto
                         Reset all the asics on the galaxy host, but do auto retries upto 3 times if reset fails.
-  --no_reinit           Don't detect devices post reset. This doesn't work on galaxy 6u trays reset.
+  -glx_reset_tray {1,2,3,4}
+                        Reset a specific tray on the galaxy.
+  --no_reinit           Don't detect devices post reset.
   ```
 
 Some of these flags will be discussed in more detail in the following sections.
@@ -226,8 +235,9 @@ If the ```disable_sw_version_report``` is set to true, all the software versions
 There are two options available for resetting WH galaxy 6u trays.
   - glx_reset: resets the galaxy, informs users if there has been an eth failure
   - glx_reset_auto: resets the galaxy upto 3 times if eth failures are detected
-Fundamentally they are the same kind of reset and errors can be captured via command line and sys exit codes.
+  - glx_reset_tray <tray_num>: performs reset on one galaxy tray. Tray number has to be between 1-4
 
+Full galaxy reset -
 ```
 tt-smi -glx_reset
  Resetting WH Galaxy trays with reset command...
@@ -237,6 +247,16 @@ Driver loaded
  Re-initializing boards after reset....
  Detected Chips: 32
  Re-initialized 32 boards after reset. Exiting...
+```
+Tray reset -
+```
+tt-smi -glx_reset_tray 3 --no_reinit
+ Resetting WH Galaxy trays with reset command...
+Executing command: sudo ipmitool raw 0x30 0x8B 0x4 0xFF 0x0 0xF
+Waiting for 30 seconds: 30
+Driver loaded
+ Re-initializing boards after reset....
+ Exiting after galaxy reset without re-initializing chips.
 ```
 
 ## Snapshots

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tt-smi"
-version = "3.0.25"
+version = "3.0.26"
 description = "ncurses based hardware monitoring for Tenstorrent silicon"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -28,7 +28,7 @@ dependencies = [
   'elasticsearch==8.11.0',
   'pydantic>=1.2',
   'tt_tools_common @ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.17',
-  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.7.5#subdirectory=crates/pyluwen',
+  'pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.7.10#subdirectory=crates/pyluwen',
   'rich==13.7.0',
   'textual==0.59.0',
   'pre-commit==3.5.0',

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -778,10 +778,17 @@ def parse_args():
         dest="glx_reset_auto",
     )
     parser.add_argument(
+        "-glx_reset_tray",
+        choices=["1", "2", "3", "4",],
+        default=None,
+        help="Reset a specific tray on the galaxy.",
+        dest="glx_reset_tray",
+    )
+    parser.add_argument(
         "--no_reinit",
         default=False,
         action="store_true",
-        help="Don't detect devices post reset. This doesn't work on galaxy 6u trays reset.",
+        help="Don't detect devices post reset.",
     )
     args = parser.parse_args()
     return args
@@ -944,6 +951,18 @@ def main():
 
         # All went well - exit
         sys.exit(0)
+    if args.glx_reset_tray is not None:
+        # Reset a specific tray on the galaxy
+        try:
+            tray_num_bitmask = hex(1 << (int(args.glx_reset_tray) - 1))
+            glx_6u_trays_reset(reinit=not(args.no_reinit), ubb_num=tray_num_bitmask, dev_num="0xFF", op_mode="0x0", reset_time="0xF")
+        except Exception as e:
+            print(
+                CMD_LINE_COLOR.RED,
+                f"Error in resetting galaxy 6u tray {args.glx_reset_tray}!\n{e}\n Exiting...",
+                CMD_LINE_COLOR.ENDC,
+            )
+            sys.exit(1)
 
     if args.generate_reset_json:
         # Use filename if provided, else use default

--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -842,17 +842,23 @@ def check_wh_galaxy_eth_link_status(devices):
         )
         # sys.exit(1)
 
-def glx_6u_trays_reset(reinit=True):
+def glx_6u_trays_reset(reinit=True, ubb_num="0xF", dev_num="0xFF", op_mode="0x0", reset_time="0xF"):
     """
     Reset the WH asics on the galaxy systems with the following steps:
     1. Reset the trays with ipmi command
     2. Wait for 30s
     3. Reinit all chips
+
+    Args:
+        reinit (bool): Whether to reinitialize the chips after reset.
+        ubb_num (str): The UBB number to reset. 0x0~0xF (bit map)
+        dev_num (str): The device number to reset. 0x0~0xFF(bit map)
+        op_mode (str): The operation mode to use.
+                        0x0 - Asserted/Deassert reset with a reset period (reset_time)
+                        0x1 - Asserted reset
+                        0x2 - Deasserted reset
+        reset_time (str): The reset time to use. resolution 10ms (ex. 0xF => 15 => 150ms)
     """
-    ubb_num = "0xF"
-    dev_num = "0xFF"
-    op_mode = "0x0"
-    reset_time = "0xF"
     print(
         CMD_LINE_COLOR.PURPLE,
         f"Resetting WH Galaxy trays with reset command...",
@@ -869,7 +875,7 @@ def glx_6u_trays_reset(reinit=True):
     if not reinit:
         print(
             CMD_LINE_COLOR.GREEN,
-            f"Exiting after galoaxy reset without re-initializing chips.",
+            f"Exiting after galaxy reset without re-initializing chips.",
             CMD_LINE_COLOR.ENDC,
         )
         sys.exit(0)
@@ -887,8 +893,10 @@ def glx_6u_trays_reset(reinit=True):
         # Error out if chips don't initalize
         sys.exit(1)
 
-    # after re-init check eth status
-    check_wh_galaxy_eth_link_status(chips)
+    # after re-init check eth status - only if doing a full galaxy reset.
+    # If doing a partial reset, eth connections will be broken because eth training will go out of sync
+    if ubb_num == 0xF:
+        check_wh_galaxy_eth_link_status(chips)
     # All went well - exit with success
     print(
         CMD_LINE_COLOR.GREEN,


### PR DESCRIPTION
- Added tray lvl reset option
- Bumped luwen 0.7.5 -> 0.7.10 that ignores eth during chip init for 6u galaxys 
- Updated readme with the new option
- Fixed typos
