### PR TITLE
Sbansal/bump python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tt-smi"
 version = "3.0.26"
 description = "ncurses based hardware monitoring for Tenstorrent silicon"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
   { name = "Sam Bansal", email = "sbansal@tenstorrent.com" }


### PR DESCRIPTION
- bump minimum required python version 3.7 -> 3.10
- ~~Pulled community PR to loosen the dependency versions~~ Removed this from the PR for now, textual bump seems to slow down the GUI. Need some more refinement till we can merge it 