### PR TITLE
Rename .deb package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Homepage: https://github.com/tenstorrent/tt-smi
 Vcs-Git: https://github.com/tenstorrent/tt-smi.git
 Vcs-Browser: https://github.com/tenstorrent/tt-smi
 
-Package: tt-smi
+Package: python3-tt-smi
 Architecture: all
 Depends:
  ${misc:Depends},


### PR DESCRIPTION
python3-tt-smi is in line with distro packages for Python

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-161) by [Unito](https://www.unito.io)
