### PR TITLE
Add Blackhole Galaxy and missing BH PCIe card board types

### DIFF
--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -659,6 +659,16 @@ def get_board_type(board_id: str) -> str:
         return "p150a"
     elif upi == 0x41:
         return "p150b"
+    elif upi == 0x42:
+        return "p150c"
+    elif upi == 0x44:
+        return "p300b"
+    elif upi == 0x45:
+        return "p300a"
+    elif upi == 0x46:
+        return "p300c"
+    elif upi == 0x47:
+        return "tt-galaxy-bh"
     else:
         return "N/A"
 


### PR DESCRIPTION
Decode and display Blackhole Galaxy, P150C, and P300A/B/C board types from board ID UPI.

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-167) by [Unito](https://www.unito.io)
