### PR TITLE
Add animation suppressed output to Galaxy 6U reset

### DIFF
--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -906,7 +906,7 @@ def main():
         try:
             # reinit has to be enabled to detect devices post reset
 
-            glx_6u_trays_reset(reinit=not(args.no_reinit))
+            glx_6u_trays_reset(reinit=not(args.no_reinit), print_status=is_tty)
         except Exception as e:
             print(
                 CMD_LINE_COLOR.RED,
@@ -932,7 +932,7 @@ def main():
             try:
                 # Try to reset galaxy 6u trays
                 # reinit has to be enabled to detect devices post reset
-                glx_6u_trays_reset(reinit=True)
+                glx_6u_trays_reset(reinit=True, print_status=is_tty)
                 break  # If reset was successful, break the loop
             except Exception as e:
                 reset_try_number += 1
@@ -956,7 +956,7 @@ def main():
         # Reset a specific tray on the galaxy
         try:
             tray_num_bitmask = hex(1 << (int(args.glx_reset_tray) - 1))
-            glx_6u_trays_reset(reinit=not(args.no_reinit), ubb_num=tray_num_bitmask, dev_num="0xFF", op_mode="0x0", reset_time="0xF")
+            glx_6u_trays_reset(reinit=not(args.no_reinit), ubb_num=tray_num_bitmask, dev_num="0xFF", op_mode="0x0", reset_time="0xF", print_status=is_tty)
         except Exception as e:
             print(
                 CMD_LINE_COLOR.RED,


### PR DESCRIPTION
Pass in print_status to glx_6u_trays_reset.

This was left out in commit 416d018.

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-177) by [Unito](https://www.unito.io)
