### PR TITLE
Bump tt-tools-common version to 1.4.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   'distro>=1.8.0',
   'elasticsearch>=8.11.0',
   'pydantic>=1.2',
-  'tt_tools_common==1.4.28',
+  'tt_tools_common==1.4.29',
   'pyluwen==0.7.11',
   'rich>=13.7.0',
   'textual>=0.59.0',


### PR DESCRIPTION
The tt-tools-common 1.4.29 update includes a fix for erroneous prints of "BH" during reset for WH chips and a change to the reset sequence after secondary bus reset was removed from the tt-kmd ASIC reset code.

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-179) by [Unito](https://www.unito.io)
