### PR TITLE
Modify short argument of --generate_reset_json from `-g` to `-grj`

### DIFF
--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -725,7 +725,7 @@ def parse_args():
         dest="filename",
     )
     parser.add_argument(
-        "-g",
+        "-grj",
         "--generate_reset_json",
         nargs="?",
         const=True,


### PR DESCRIPTION
If the short argument for `--generate_reset_json` is set to `-g`, there's problem where any other argument starting with `-g` (such as `-glx_reset`) could mistakenly trigger `--generate_reset_json` if it's typed incorrectly.
For examplee, if someone runs `tt-smi -glx_rsset` by mistake, the problem interprets it as executing `--generate_reset_json lx_rsset` with lx_rsset as the filename.

To avoid this issue, the short argument should be changed from `-g` to `--grj`.

┆Issue is synchronized with this [Jira Task](https://tenstorrent.atlassian.net/browse/SSTNU-192) by [Unito](https://www.unito.io)
