### PR TITLE
Use importlib instead of deprecated pkg_resources from setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ dependencies = [
   'rich>=13.7.0',
   'textual>=0.59.0',
   'pre-commit>=3.5.0',
-  'importlib_resources>=6.1.1',
-  'setuptools',
   'tomli',
 ]
 

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -16,11 +16,11 @@ import time
 import signal
 import argparse
 import threading
-import pkg_resources
 from rich.text import Text
 from tt_smi import constants
 from typing import List, Tuple, Union
-from importlib_resources import files
+from importlib.resources import files
+from importlib.metadata import version
 from pyluwen import pci_scan
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches
@@ -95,7 +95,7 @@ class TTSMI(App):
         self,
         result_filename: str = None,
         app_name: str = "TT-SMI",
-        app_version: str = pkg_resources.get_distribution("tt_smi").version,
+        app_version: str = version("tt_smi"),
         key_bindings: TextualKeyBindings = [],
         backend: TTSMIBackend = None,
         snapshot: bool = False,
@@ -698,7 +698,7 @@ def parse_args():
         "-v",
         "--version",
         action="version",
-        version=pkg_resources.get_distribution("tt_smi").version,
+        version=version("tt_smi"),
     )
     parser.add_argument(
         "-s",

--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -12,7 +12,6 @@ import re
 import sys
 import time
 import datetime
-import pkg_resources
 from tt_smi import log
 from pathlib import Path
 from rich.table import Table
@@ -21,6 +20,7 @@ from rich import get_console
 from rich.syntax import Syntax
 from typing import Dict, List
 from rich.progress import track
+from importlib.metadata import version
 from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
 from tt_tools_common.reset_common.wh_reset import WHChipReset
 from tt_tools_common.reset_common.bh_reset import BHChipReset
@@ -685,8 +685,8 @@ def dict_from_public_attrs(obj) -> dict:
 
 def get_host_software_versions() -> dict:
     return {
-        "tt_smi": pkg_resources.get_distribution("tt_smi").version,
-        "pyluwen": pkg_resources.get_distribution("pyluwen").version,
+        "tt_smi": version("tt_smi"),
+        "pyluwen": version("pyluwen"),
     }
 
 


### PR DESCRIPTION
Use importlib.metadata to get package versions and importlib.resources to get files. I think we can also drop importlib_resources as we only support python >=3.10 now and it is a backport of importlib.resources for older versions.