### PR TITLE
Properly compute and display negative ASIC temp values

### DIFF
--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -416,7 +416,9 @@ class TTSMIBackend:
 
     def convert_signed_16_16_to_float(self, value):
         """Convert signed 16.16 to float"""
-        return (value >> 16) + (value & 0xFFFF) / 65536.0
+        if value & (1 << (32 - 1)): # if the value is negative (two's complement)
+            value -= 1 << 32 # convert to negative value
+        return value / 65536.0
 
     def get_bh_chip_telemetry(self, board_num) -> Dict:
         """Get telemetry data for bh chip. None if ARC FW not running"""


### PR DESCRIPTION
ASIC temperature in BH telemetry is a 16.16 fixed point integer signed using two's complement. Negative values weren't being computed and so were being displayed as 65536 - temp.

Kind of rare but there are scenarios in the lab where core temp is negative...

Before:
<img width="1087" height="256" alt="image" src="https://github.com/user-attachments/assets/d141d218-365b-470b-befb-cdeb5c876321" />

After:
<img width="1101" height="224" alt="image" src="https://github.com/user-attachments/assets/2fdc0e34-27a7-4f53-8c09-f060925b6452" />
