### PR TITLE
Add in fields with a value of 0 when constructing smbus_telem_info

### DIFF
--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -251,8 +251,7 @@ class TTSMIBackend:
         smbus_telem_dict = dict.fromkeys(constants.SMBUS_TELEMETRY_LIST)
 
         for key, value in json_map.items():
-            if value:
-                smbus_telem_dict[key.upper()] = hex(value)
+            smbus_telem_dict[key.upper()] = hex(value)
         return smbus_telem_dict
 
     def update_telem(self):


### PR DESCRIPTION
Currently, when `get_smbus_board_info` constructs a telemetry dict from values obtained from pyluwen `get_telemetry`, telemetry fields with a value of 0 are skipped. This is a bug as a value of 0 is meaningful and doesn't necessarily mean the telemetry val is unpopulated, e.g. ASIC_LOCATION = 0 or ASIC_TEMPERATURE = 0.

This changes the behaviour of `tt-smi -s`, causing some values that previously were null to be 0 instead. It may also add in fields on top of those in `constants.SMBUS_TELEMETRY_LIST` that were previously not present due to having a 0 value.

Anything that checks for the presence of a telemetry key in `tt-smi -s` will have to be changed to checking if its value is 0.

This will resolve https://github.com/tenstorrent/tt-smi/issues/170.

**Further discussion:**
- We can probably remove `BH_TELEMETRY_LIST` in `constants.py` entirely as it's not used anymore.
- Do we need `SMBUS_TELEMETRY_LIST`? The only reason we really need it is to promise that certain telemetry keys will be a part of `tt-smi -s` (not necessarily populated), whatever FW and device type you're using. The way it currently works, telemetry keys get added in on top of what's in that list.
- What do we promise to provide in `smbus_telem` when users run `tt-smi -s`?