### PR TITLE
Change update_telem thread to use Textual Worker API

### DIFF
--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -760,7 +760,8 @@ def main():
     First entry point for TT-SMI. Detects devices and instantiates backend.
     """
     # Enable backtrace for debugging
-    os.environ["RUST_BACKTRACE"] = "full"
+    # "0" is no backtrace, "1" is short backtrace, "full" is full backtrace
+    # os.environ["RUST_BACKTRACE"] = "full"
 
     args = parse_args()
 


### PR DESCRIPTION
Move away from using threading directly to using Textual's Worker API, which can exit and display a traceback on error. This is to address #168.

I don't have exit_on_error set to True for the telemetry thread right now, so the behaviour is if you reset in another tt-smi instance, the thread will still silently terminate.

Do we instead want to quit the application when the telemetry thread fails? In the situation where it fails, the user will need to stop and restart tt-smi to get the telemetry tab to start updating again.