### PR TITLE
add option --eth_train_skip, which enables skipping eth training

### DIFF
--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -685,6 +685,12 @@ def parse_args():
         action="store_true",
         help="Use deprecated Luwen driver instead of UMD (default).",
     )
+    parser.add_argument(
+        "--eth_train_skip",
+        default=False,
+        action="store_true",
+        help="Skip waiting for Ethernet training post reset when using UMD.",
+    )
     args = parser.parse_args()
     return args
 
@@ -766,11 +772,11 @@ def main():
         if reset_input.type == ResetType.ALL:
             # Assume user wants all pci devices to be reset
             reset_indices = pci_scan()
-            pci_board_reset(reset_indices, reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen)
+            pci_board_reset(reset_indices, reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen, wait_for_eth=not args.eth_train_skip)
 
         elif reset_input.type == ResetType.ID_LIST:
             reset_indices = reset_input.value
-            pci_board_reset(reset_indices, reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen)
+            pci_board_reset(reset_indices, reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen, wait_for_eth=not args.eth_train_skip)
 
         # All went well - exit
         sys.exit(0)

--- a/tt_smi/tt_smi_reset.py
+++ b/tt_smi/tt_smi_reset.py
@@ -22,6 +22,7 @@ from tt_umd import (
     WarmReset,
     PCIDevice,
     TopologyDiscovery,
+    TopologyDiscoveryOptions,
 )
 from tt_tools_common.utils_common.tools_utils import (
     detect_chips_with_callback,
@@ -110,6 +111,7 @@ def pci_board_reset(
     reinit: bool = False,
     print_status: bool = True,
     use_umd: bool = False,
+    wait_for_eth: bool = True,
 ):
     """Given a list of PCI index's init the PCI chip and call reset on it"""
     reset_wh_pci_idx = []
@@ -181,7 +183,15 @@ def pci_board_reset(
         )
         try:
             if use_umd:
-                TopologyDiscovery.discover()
+                options = TopologyDiscoveryOptions()
+                options.no_wait_for_eth_training = not wait_for_eth
+                if not wait_for_eth:
+                    print(
+                        CMD_LINE_COLOR.YELLOW,
+                        "Skipping Ethernet link training wait after reset.",
+                        CMD_LINE_COLOR.ENDC,
+                    )
+                TopologyDiscovery.discover(options)
             else:
                 detect_chips_with_callback(print_status=print_status)
         except Exception as e:


### PR DESCRIPTION
add the flag --eth_train_skip, which allows a user to skip Ethernet
training after a reset. This can be useful for resets where the
user only cares that the SMC is accessible.
