### PR TITLE
Check if telem value is not None before converting to hex for smbus_telem_dict

### DIFF
--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -305,7 +305,9 @@ class TTSMIBackend:
         smbus_telem_dict = dict.fromkeys(constants.SMBUS_TELEMETRY_LIST)
 
         for key, value in json_map.items():
-            smbus_telem_dict[key.upper()] = hex(value)
+            if value is not None:
+                value = hex(value)
+            smbus_telem_dict[key.upper()] = value
         return smbus_telem_dict
 
     def update_telem(self):


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/tenstorrent/tt-smi/pull/195.

In get_smbus_board_info, I made a change in #195 to remove the check for if `value` was falsy before adding it to the smbus_telem_dict. This was intended to allow values of 0 to be entered in, but now None values throw an error when attempting to convert them to hex.