### PR TITLE
Add CPLD FW version check to improve messaging on tt-smi -r on Galaxy

### DIFF
--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -807,12 +807,26 @@ def main():
     # Handle ubb reset without backend
     if args.glx_reset:
         # Galaxy reset, without auto retries
-        try:
+        # Messaging about tt-smi -r availability
+        print(
+            CMD_LINE_COLOR.YELLOW,
+            "Hint: tt-smi -r is now supported on Galaxy 6U. CPLD FW v1.16 or higher is required. Checking CPLD FW version for compatability...",
+            CMD_LINE_COLOR.ENDC,
+        )
+        cpld_fw_vers = glx_6u_get_cpld_fw_version()
+        if all(fw_ver >= (1, 16, 0) for fw_ver in cpld_fw_vers.values()):
             print(
                 CMD_LINE_COLOR.YELLOW,
-                "Hint: tt-smi -r is now supported on Galaxy 6U.",
+                "CPLD FW version on this Galaxy is sufficient. Try tt-smi -r next time.",
                 CMD_LINE_COLOR.ENDC,
             )
+        else:
+            print(
+                CMD_LINE_COLOR.YELLOW,
+                "CPLD FW version on this Galaxy is insufficient. Please continue to use tt-smi -glx_reset and contact your system administrator to request a CPLD update.",
+                CMD_LINE_COLOR.ENDC,
+            )
+        try:
             # reinit has to be enabled to detect devices post reset
             glx_6u_trays_reset(reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen)
         except Exception as e:


### PR DESCRIPTION
Add CPLD FW version check to improve messaging about `tt-smi -r` usage on Galaxy.

Before, we printed a hint message when users ran `tt-smi -glx_reset` that `tt-smi -r` is now available on Galaxy, and added messaging about CPLD FW version requirements when Galaxy users ran `tt-smi -r`, but didn't actually run a CPLD FW version check for customized messaging.

The way we have of checking CPLD FW version is through ipmitool commands right now. We can't assume that the user has access to sudo or ipmitool if they're running `tt-smi -r`, so we can't do the version check there. Instead, add the version check to `tt-smi -glx_reset` to guide users to the best command for them to use.

I am also removing the warning message from `tt-smi -r`, but we still have no good way of telling if a reset failure was due to an insufficient CPLD FW version or something else. The main reasons I'm removing it are that improved information can now be gathered from `-glx_reset` and I don't want to spam users about a problem that most won't run into. It should probably be moved to an error message instead.