### PR TITLE
Modernize the firmware table

### DIFF
--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -174,7 +174,8 @@ class TestSnapshot:
             assert "cm_fw" in firmwares
             assert "cm_fw_date" in firmwares
             assert "eth_fw" in firmwares
-            assert "bm_bl_fw" in firmwares
+            assert "dm_bl_fw" in firmwares
+            assert "dm_app_fw" in firmwares
 
     def test_limits_fields(self, snapshot):
         """Test if fields are present in limits."""

--- a/tt_smi/constants.py
+++ b/tt_smi/constants.py
@@ -120,14 +120,23 @@ LIMITS = [
     "bus_peak_limit",
 ]
 
-FW_LIST = [
+# leaving this intact for the snapshot version of the firmware list 
+# Don't want to break any automations we have around the snapshot
+FW_LIST_SNAPSHOT = [
     "fw_bundle_version",
     "tt_flash_version",
     "cm_fw",
     "cm_fw_date",
     "eth_fw",
-    "bm_bl_fw",
-    "bm_app_fw",
+    "dm_bl_fw",
+    "dm_app_fw",
+]
+
+FW_LIST_GUI = [
+    "fw_bundle_version",
+    "cm_fw",
+    "eth_fw",
+    "dm_app_fw",
 ]
 
 DEV_INFO_LIST = [
@@ -189,12 +198,9 @@ TELEMETRY_TABLE_HEADER = [
 FIRMWARES_TABLE_HEADER = [
     "#",
     "FW Bundle Version",
-    "TT-Flash Version",
     "CM FW Version",
-    "CM FW Date",
     "ETH FW Version",
-    "BM BL Version",
-    "BM App Version",
+    "DM App Version",
 ]
 
 PCI_PROPERTIES = [

--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -234,11 +234,11 @@ class Telemetry(ElasticModel):
 
 @optional
 class Firmwares(ElasticModel):
-    arc_fw: str
-    arc_fw_date: str
+    cm_fw: str
+    cm_fw_date: str
     eth_fw: str
-    m3_bl_fw: str
-    m3_app_fw: str
+    dm_bl_fw: str
+    dm_app_fw: str
     tt_flash_version: str
 
 

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -37,10 +37,11 @@ from tt_tools_common.reset_common.reset_utils import (
 from tt_smi.tt_smi_backend import (
     TTSMIBackend,
     pci_board_reset,
-    glx_6u_trays_reset
+    hex_to_semver_eth,
+    glx_6u_trays_reset,
+    hex_to_semver_m3_fw,
 )
 from tt_tools_common.utils_common.tools_utils import (
-    hex_to_semver_m3_fw,
     detect_chips_with_callback,
 )
 from tt_tools_common.utils_common.system_utils import (
@@ -175,9 +176,9 @@ class TTSMI(App):
         all_rows = []
         for i in self.backend.devices:
             rows = [Text(f"{i}", style=self.text_theme["yellow_bold"], justify="center")]
-            for fw in constants.FW_LIST:
+            for fw in constants.FW_LIST_GUI:
                 val = self.backend.firmware_infos[i][fw]
-                if val == "N/A":
+                if val == "N/A" or val == hex_to_semver_m3_fw(0) or val == hex_to_semver_eth(0):
                     rows.append(
                         Text(f"{val}", style=self.text_theme["gray"], justify="center")
                     )


### PR DESCRIPTION
- Update all instances of arc_fw -> cm_fw.
- Update all instances of bm/m3_fw -> dm_fw.
- Separated the GUI and snapshot fw reporting. Removed cm_fw_date, tt_flash_version and dm_app_fw from the GUI to avoid visual clutter with non relevant fields.
- Kept all the fields in snapshot so the information is available still to interested parties.
- Removed dependance of parsing hex_to_semver functions from tt-tools-common and moved to smi backend instead as an ongoing effort to depreciate that library.

FW table  on BH galaxy looks like this now -
<img width="862" height="358" alt="image" src="https://github.com/user-attachments/assets/8a2ac49f-11b7-4440-b18f-b4c5d9af265c" />
Snapshot on BH glx
<img width="321" height="157" alt="image" src="https://github.com/user-attachments/assets/d8bc7e0b-6f5b-4276-a778-a25706ddc1b4" />

FW table on WH glx - 
<img width="1078" height="426" alt="image" src="https://github.com/user-attachments/assets/b8922e7f-dc72-429c-b471-eec71ac9ae4d" />
Snapshot on WH glx - 
<img width="266" height="130" alt="image" src="https://github.com/user-attachments/assets/d07dbfce-adb5-4676-9431-8e75eda9a55f" />


