### PR TITLE
Fix not passing in secondary_bus_reset to BH full_lds_reset

### DIFF
--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -884,7 +884,7 @@ def pci_board_reset(list_of_boards: List[int], reinit: bool = False, print_statu
             WHChipReset().full_lds_reset(pci_interfaces=reset_wh_pci_idx, secondary_bus_reset=secondary_bus_reset)
 
         if reset_bh_pci_idx:
-            BHChipReset().full_lds_reset(pci_interfaces=reset_bh_pci_idx)
+            BHChipReset().full_lds_reset(pci_interfaces=reset_bh_pci_idx, secondary_bus_reset=secondary_bus_reset)
 
     if reinit:
         # Enable backtrace for debugging


### PR DESCRIPTION
This is related to the luwen/tt-tools-common `tt-smi -r` reset on BH Galaxy only. Fix a regression introduced in #192 that causes SBR to be executed on BH Galaxy when running `tt-smi -r --use_luwen`.