### PR TITLE
Fix DRAM trained reporting on p100a (harvested channel)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,11 @@
 
 import pytest
 
-from tt_smi.tt_smi_utils import get_board_type, convert_signed_16_16_to_float
+from tt_smi.tt_smi_utils import (
+    get_board_type,
+    convert_signed_16_16_to_float,
+    check_blackhole_dram_training_status,
+)
 
 class TestGetBoardType:
     @pytest.mark.parametrize(
@@ -78,3 +82,64 @@ class TestDataFormatting:
     def test_convert_signed_16_16_to_float(self, raw, expected):
         """Test converting signed 16.16 fixed-point number to float."""
         assert convert_signed_16_16_to_float(raw) == pytest.approx(expected)
+
+
+class TestBlackholeDramTrainingStatus:
+    """
+    Tests for check_blackhole_dram_training_status.
+
+    DDR_STATUS packs 2 bits per GDDR channel for training status (bits 0..15)
+    and, on FW >= 19.7.0.3, another 2 bits per channel for BIST status
+    (bits 16..31): bit 2i = complete, bit 2i + 1 = error/failed.
+
+    A fully-trained 8-channel Blackhole reports DDR_STATUS == 0x55555555
+    (modern) or 0x5555 (legacy). p100a ships with channel 3 harvested
+    (ENABLED_GDDR = 0xF7) and the channel 3 bits read back zero.
+    """
+
+    # --- FW >= 19.7.0.3 (32-bit DDR_STATUS with BIST) ---
+
+    def test_full_8ch_pass(self):
+        assert check_blackhole_dram_training_status(0x55555555, 0xFF, has_bist=True)
+
+    def test_p100a_7ch_pass(self):
+        # Real observed value on a healthy p100a (channel 3 harvested).
+        assert check_blackhole_dram_training_status(0x55155515, 0xF7, has_bist=True)
+
+    def test_enabled_channel_missing_train_complete(self):
+        # Channel 2 (bits 4-5) cleared.
+        assert not check_blackhole_dram_training_status(
+            0x55155505, 0xF7, has_bist=True
+        )
+
+    def test_enabled_channel_train_error_set(self):
+        # Channel 0 error bit (bit 1) set.
+        assert not check_blackhole_dram_training_status(
+            0x55155517, 0xF7, has_bist=True
+        )
+
+    def test_enabled_channel_bist_failed(self):
+        # Channel 0 BIST-failed bit (bit 17) set.
+        assert not check_blackhole_dram_training_status(
+            0x55175515, 0xF7, has_bist=True
+        )
+
+    def test_disabled_channel_bits_ignored(self):
+        # Channel 3 bits deliberately dirty but channel 3 is disabled -> still pass.
+        assert check_blackhole_dram_training_status(0x55D555D5, 0xF7, has_bist=True)
+
+    # --- FW < 19.7.0.3 (16-bit DDR_STATUS, no BIST bits) ---
+
+    def test_legacy_full_8ch_pass(self):
+        assert check_blackhole_dram_training_status(0x5555, 0xFF, has_bist=False)
+
+    def test_legacy_p100a_7ch_pass(self):
+        assert check_blackhole_dram_training_status(0x5515, 0xF7, has_bist=False)
+
+    def test_legacy_ignores_upper_bits(self):
+        # Upper bits are undefined on legacy FW and must not affect the decision.
+        assert check_blackhole_dram_training_status(0xFFFF5555, 0xFF, has_bist=False)
+
+    def test_legacy_error_bit_set(self):
+        # Channel 0 error bit set.
+        assert not check_blackhole_dram_training_status(0x5557, 0xFF, has_bist=False)

--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -32,7 +32,8 @@ from tt_smi.tt_smi_utils import (
     convert_signed_16_16_to_float,
     dict_from_public_attrs,
     get_host_software_versions,
-    get_fw_bundle_version
+    get_fw_bundle_version,
+    check_blackhole_dram_training_status,
 )
 from tt_umd import (
     TTDevice,
@@ -472,40 +473,21 @@ class TTSMIBackend:
                 return True
             return False
         elif self.is_blackhole(board_num):
+            if self.smbus_telem_info[board_num]["DDR_STATUS"] is None:
+                return False
             dram_status = int(self.smbus_telem_info[board_num]["DDR_STATUS"], 16)
-            if int(get_fw_bundle_version(self.smbus_telem_info[board_num]), 16) >= 0x13070000:
-                # After FW version 19.7.0.3 (hex 0x13070003), the dram status is a 16-bit field with the following layout:
-                # DDR Status:
-                # [0]  - Training complete GDDR 0
-                # [1]  - Error GDDR 0
-                # [2]  - Training complete GDDR 1
-                # [3]  - Error GDDR 1
-                # ...
-                # [14] - Training complete GDDR 7
-                # [15] - Error GDDR 7
-                # [16] - BIST complete GDDR 0
-                # [17] - BIST failed GDDR 0
-                # [18] - BIST complete GDDR 1
-                # [19] - BIST failed GDDR 1
-                # ...
-                # [30] - BIST complete GDDR 7
-                # [31] - BIST failed GDDR 7
-                if dram_status == 0x55555555:
-                    return True
-                return False
-            else:
-                # Pre-19.7.0.3 DDR Status in BH is a 16-bit field with the following layout:
-                #  [0] - Training complete GDDR 0
-                #  [1] - Error GDDR 0
-                #  [2] - Training complete GDDR 1
-                #  [3] - Error GDDR 1
-                #  ...
-                #  [14] - Training Complete GDDR 7
-                #  [15] - Error GDDR 7
-                # 0x5555 = 0b0101010101010101 means all 8 channels trained successfully
-                if dram_status == 0x5555:
-                    return True
-                return False
+            # ENABLED_GDDR is the per-channel enable mask; reduced-channel SKUs
+            # like p100a ship with fewer than 8 bits set. Fall back to all-8
+            # for older firmware that doesn't expose it.
+            enabled_gddr_raw = self.smbus_telem_info[board_num].get("ENABLED_GDDR")
+            enabled_gddr = int(enabled_gddr_raw, 16) if enabled_gddr_raw is not None else 0xFF
+            has_bist = (
+                int(get_fw_bundle_version(self.smbus_telem_info[board_num]), 16)
+                >= 0x13070000
+            )
+            return check_blackhole_dram_training_status(
+                dram_status, enabled_gddr, has_bist
+            )
         else:
             return False
 

--- a/tt_smi/tt_smi_utils.py
+++ b/tt_smi/tt_smi_utils.py
@@ -195,6 +195,39 @@ def get_fw_bundle_version(smbus_telem_info) -> int:
     else:
         return None
 
+
+def check_blackhole_dram_training_status(
+    dram_status: int, enabled_gddr: int, has_bist: bool
+) -> bool:
+    """
+    Check if every enabled GDDR channel on a Blackhole board has trained successfully.
+
+    Blackhole has up to 8 GDDR6 channels, but some SKUs ship with fewer enabled
+    via the ENABLED_GDDR firmware mask (e.g. p100a has 7/8 enabled by design).
+    The previous check compared DDR_STATUS against the literal "all 8 pass"
+    pattern (0x55555555), which always reports a false 'not trained' on
+    reduced-channel SKUs. This helper ignores bits for disabled channels.
+
+    DDR_STATUS layout, 2 bits per channel:
+        bit 2i     : channel i training complete
+        bit 2i + 1 : channel i training error
+        bit 2i + 16: channel i BIST complete   (FW >= 19.7.0.3 only)
+        bit 2i + 17: channel i BIST failed     (FW >= 19.7.0.3 only)
+    """
+    for channel in range(8):
+        if not (enabled_gddr & (1 << channel)):
+            continue
+        train_complete = (dram_status >> (2 * channel)) & 0x1
+        train_error = (dram_status >> (2 * channel + 1)) & 0x1
+        if not train_complete or train_error:
+            return False
+        if has_bist:
+            bist_complete = (dram_status >> (2 * channel + 16)) & 0x1
+            bist_failed = (dram_status >> (2 * channel + 17)) & 0x1
+            if not bist_complete or bist_failed:
+                return False
+    return True
+
 def get_dev_id_from_bdf(bdf: str) -> int:
     """
     Resolve /dev/tenstorrent index N from a PCI BDF. Validates that the device


### PR DESCRIPTION
NB: this is very much vibe-coded so feel free to discard in favor of an internal impl if preferred.  The issue being addressed here is tt-smi always shows DRAM as being untrained on p100a cards because the existing check in code doesn't properly handle the case of an intentionally disabled memory channel.  I verified tt-smi shows DRAM as trained on my p100a after this change.

---- Vibes below ----

## Summary

The Blackhole branch of `get_dram_training_status` in `tt_smi_backend.py` compared `DDR_STATUS` against the literal "all 8 channels pass" pattern (`0x55555555` on FW >= 19.7.0.3, `0x5555` on legacy), which guarantees a false `DRAM Trained = N` on any SKU that ships with fewer than 8 GDDR channels enabled.

The p100a ships with 7/8 channels enabled by design (`ENABLED_GDDR = 0xF7`, channel 3 harvested) — see the [product page](https://tenstorrent.com/hardware/blackhole) noting "28 GB of GDDR6" vs. a full-8-channel Blackhole's 32 GB. Every healthy p100a therefore reports `N` in the GUI and `dram_status: false` in `tt-smi -s` output, even though all enabled channels are fully trained and BIST-clean.

## Root cause

On a real p100a running FW 19.7.1.0:

- `DDR_STATUS = 0x55155515`
- `ENABLED_GDDR = 0xf7`

Decoding `0x55155515` bit-by-bit against the layout from #210:

| GDDR ch | train complete | train err | BIST complete | BIST failed | Enabled? |
|---|---|---|---|---|---|
| 0 | ✓ | — | ✓ | — | ✓ |
| 1 | ✓ | — | ✓ | — | ✓ |
| 2 | ✓ | — | ✓ | — | ✓ |
| 3 | — | — | — | — | **✗** |
| 4 | ✓ | — | ✓ | — | ✓ |
| 5 | ✓ | — | ✓ | — | ✓ |
| 6 | ✓ | — | ✓ | — | ✓ |
| 7 | ✓ | — | ✓ | — | ✓ |

Every enabled channel is trained + BIST-clean. Channel 3 is cleanly skipped (no training attempted, no error), consistent with it being fuse/firmware-harvested. But the `== 0x55555555` check has no way to account for that.

## Fix

Extract the bit check into a pure helper `check_blackhole_dram_training_status(dram_status, enabled_gddr, has_bist)` in `tt_smi_utils.py` that iterates channels 0..7 and only checks bits for channels set in `enabled_gddr`. For each enabled channel it verifies `train_complete == 1 && train_error == 0`, and on FW >= 19.7.0.3 additionally `bist_complete == 1 && bist_failed == 0`. Falls back to `0xFF` when `ENABLED_GDDR` is absent from telemetry, preserving existing behavior on older firmware.

Also added a `None` guard on `DDR_STATUS` to match the Wormhole branch.

## Test plan

- [x] New unit tests in `tests/test_utils.py::TestBlackholeDramTrainingStatus` covering:
  - Full 8-channel pass (modern and legacy FW formats)
  - The real observed p100a value `0x55155515` with `ENABLED_GDDR=0xF7`
  - Enabled channel missing `train_complete`
  - Enabled channel with `train_error` set
  - Enabled channel with `bist_failed` set
  - **Disabled channel bits ignored** (dirty channel-3 bits, still passes)
  - Legacy format variants of the above
- [x] 34/34 tests in `test_utils.py` pass locally, including the 2 `requires_hardware` tests against a real p100a.
- [x] End-to-end verified on a p100a with FW 19.7.1.0: `tt-smi -s` now reports `"dram_status": true` with the same raw telemetry where it previously reported `false`.