### PR TITLE
Fix waiting on ethernet training when using `eth_train_skip` option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Tuple, Union
 from pyluwen import pci_scan, PciChip
 from tt_umd import PCIDevice, TopologyDiscovery, TTDevice, TopologyDiscoveryOptions
 from tt_smi.tt_smi_backend import TTSMIBackend
-from tt_smi.constants import SMBUS_TELEMETRY_OPTIONS
+from tt_smi.constants import get_default_discovery_options
 from tt_tools_common.utils_common.tools_utils import detect_chips_with_callback
 
 # Luwen fixtures
@@ -50,7 +50,7 @@ def umd_reset_test_config() -> Tuple[List[int], bool]:
 def umd_devices() -> dict[int, TTDevice]:
     """Return fresh Tenstorrent TTDevices for each test."""
     # Ignore eth heartbeat failures for now. Not relevant to tests.
-    _, devices = TopologyDiscovery.discover(options=SMBUS_TELEMETRY_OPTIONS)
+    _, devices = TopologyDiscovery.discover(options=get_default_discovery_options())
     try:
         yield devices
     finally:
@@ -60,7 +60,7 @@ def umd_devices() -> dict[int, TTDevice]:
 @pytest.fixture(scope="function")
 def umd_backend() -> TTSMIBackend:
     """Return a TTSMIBackend instance using UMD backend."""
-    cluster_descriptor, devices = TopologyDiscovery.discover(options=SMBUS_TELEMETRY_OPTIONS)
+    cluster_descriptor, devices = TopologyDiscovery.discover(options=get_default_discovery_options())
     return TTSMIBackend(devices=devices, umd_cluster_descriptor=cluster_descriptor)
 
 

--- a/tt_smi/constants.py
+++ b/tt_smi/constants.py
@@ -8,11 +8,13 @@ from tt_umd import (
     TopologyDiscoveryOptions,
 )
 
-SMBUS_TELEMETRY_OPTIONS = TopologyDiscoveryOptions()
-SMBUS_TELEMETRY_OPTIONS.eth_fw_mismatch_action = TopologyDiscoveryOptions.Action.IGNORE
-SMBUS_TELEMETRY_OPTIONS.eth_fw_heartbeat_failure = TopologyDiscoveryOptions.Action.IGNORE
-SMBUS_TELEMETRY_OPTIONS.cmfw_mismatch_action = TopologyDiscoveryOptions.Action.IGNORE
-SMBUS_TELEMETRY_OPTIONS.unexpected_routing_firmware_config = TopologyDiscoveryOptions.Action.IGNORE
+def get_default_discovery_options():
+    options = TopologyDiscoveryOptions()
+    options.eth_fw_mismatch_action = TopologyDiscoveryOptions.Action.IGNORE
+    options.eth_fw_heartbeat_failure = TopologyDiscoveryOptions.Action.IGNORE
+    options.cmfw_mismatch_action = TopologyDiscoveryOptions.Action.IGNORE
+    options.unexpected_routing_firmware_config = TopologyDiscoveryOptions.Action.IGNORE
+    return options
 
 SMBUS_TELEMETRY_LIST = [
     "BOARD_ID",

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -301,7 +301,7 @@ def main():
 
     try:
         if not args.use_luwen:
-            cluster_descriptor, devices = TopologyDiscovery.discover(options=constants.SMBUS_TELEMETRY_OPTIONS)
+            cluster_descriptor, devices = TopologyDiscovery.discover(options=constants.get_default_discovery_options())
         else:
             cluster_descriptor = None
             devices = dict(enumerate(detect_chips_with_callback(

--- a/tt_smi/tt_smi_reset.py
+++ b/tt_smi/tt_smi_reset.py
@@ -19,7 +19,7 @@ from tt_tools_common.reset_common.wh_reset import WHChipReset
 from tt_tools_common.reset_common.bh_reset import BHChipReset
 from tt_tools_common.reset_common.chip_reset import ChipReset, IoctlResetFlags
 from tt_smi.tt_smi_utils import get_dev_id_from_bdf
-from tt_smi.constants import SMBUS_TELEMETRY_OPTIONS
+from tt_smi.constants import get_default_discovery_options
 from pyluwen import (
     PciChip,
     pci_scan,
@@ -344,7 +344,7 @@ def pci_board_reset(
         )
         try:
             if use_umd:
-                options = copy(SMBUS_TELEMETRY_OPTIONS)
+                options = get_default_discovery_options()
                 if eth_train_skip:
                     options.discover_remote_devices = False
                     options.wait_on_ethernet_link_training = False

--- a/tt_smi/tt_smi_reset.py
+++ b/tt_smi/tt_smi_reset.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 import time
-from copy import copy
 from enum import Enum
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union, Dict
@@ -348,7 +347,7 @@ def pci_board_reset(
                 if eth_train_skip:
                     options.discover_remote_devices = False
                     options.wait_on_ethernet_link_training = False
-                TopologyDiscovery.discover(options)
+                TopologyDiscovery.discover(options=options)
             else:
                 os.environ["RUST_BACKTRACE"] = "full"
                 detect_chips_with_callback(print_status=print_status, ignore_ethernet=eth_train_skip)

--- a/tt_smi/tt_smi_reset.py
+++ b/tt_smi/tt_smi_reset.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import time
+from copy import copy
 from enum import Enum
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union, Dict
@@ -343,9 +344,11 @@ def pci_board_reset(
         )
         try:
             if use_umd:
+                options = copy(SMBUS_TELEMETRY_OPTIONS)
                 if eth_train_skip:
-                    SMBUS_TELEMETRY_OPTIONS.discover_remote_devices = False
-                TopologyDiscovery.discover(SMBUS_TELEMETRY_OPTIONS)
+                    options.discover_remote_devices = False
+                    options.wait_on_ethernet_link_training = False
+                TopologyDiscovery.discover(options)
             else:
                 os.environ["RUST_BACKTRACE"] = "full"
                 detect_chips_with_callback(print_status=print_status, ignore_ethernet=eth_train_skip)


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-umd/issues/2460

### Description
This PR fixes `tt-smi -r` incorrectly waiting on ethernet training when `eth_train_skip` is passed.

### List of the changes
- Change `SMBUS_TELEMETRY_OPTIONS` to `get_default_discovery_options()`.
- Set `wait_on_ethernet_link_training = False` on reset flow.
