### PR TITLE
Make the pyinstaller binaries actual release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,31 +320,11 @@ jobs:
               "commit_template": "- #{{TITLE}} (#{{MERGE_SHA}}) by @#{{AUTHOR}}"
             }
 
-      - name: Find the deb & whl files
+      - name: Find whl files
         run: |
-          find ${GITHUB_WORKSPACE} -type f -iname \*.deb -o -iname \*.whl -exec ls -lah {} \;
+          find ${GITHUB_WORKSPACE} -type f -iname \*.whl -exec ls -lah {} \;
           find /home/runner/work/${{ env.project_name }}/${{ env.project_name }}/ -exec ls -lah {} \;
 
-      - name: Deb file renames so they don't overlap
-        run: |
-          for x in $( \
-            find ${GITHUB_WORKSPACE} -type f -iname \*.deb | \
-            grep -v "artifacts-ubuntu" \
-          )
-          do
-            want="$( \
-              echo "${x}" | \
-              xargs dirname | \
-              tr "/" "\n" | \
-              tail -n 1 \
-              )"
-            mv -v \
-              "${x}" \
-              "$( echo "${x}" | xargs dirname )/${want}"
-          done
-
-      # PyInstaller job names the *artifact* tt-smi-<ver>-<os>; download extracts as that folder + tt-smi.
-      # GitHub release assets need unique basenames, so rename to match the artifact folder name.
       - name: Unique names for PyInstaller binaries
         run: |
           set -euxo pipefail
@@ -360,8 +340,6 @@ jobs:
         with:
           tag_name: v${{ needs.versionchange.outputs.package_version_new }}
           files: |
-            ${{ github.workspace }}/${{ env.project_name }}*/*.deb
-            ${{ github.workspace }}/[!artifacts-]*/*.deb
             ${{ github.workspace }}/*/*.whl
             ${{ github.workspace }}/tt-smi-*-ubuntu-*/tt-smi-*-ubuntu-*
           body: ${{ steps.build_changelog.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,17 @@ jobs:
               "$( echo "${x}" | xargs dirname )/${want}"
           done
 
+      # PyInstaller job names the *artifact* tt-smi-<ver>-<os>; download extracts as that folder + tt-smi.
+      # GitHub release assets need unique basenames, so rename to match the artifact folder name.
+      - name: Unique names for PyInstaller binaries
+        run: |
+          set -euxo pipefail
+          shopt -s nullglob
+          for d in "${GITHUB_WORKSPACE}"/tt-smi-*-ubuntu-*; do
+            [[ -d "${d}" && -f "${d}/tt-smi" ]] || continue
+            mv -v "${d}/tt-smi" "${d}/$(basename "${d}")"
+          done
+
       - name: Create GitHub Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -352,6 +363,7 @@ jobs:
             ${{ github.workspace }}/${{ env.project_name }}*/*.deb
             ${{ github.workspace }}/[!artifacts-]*/*.deb
             ${{ github.workspace }}/*/*.whl
+            ${{ github.workspace }}/tt-smi-*-ubuntu-*/tt-smi-*-ubuntu-*
           body: ${{ steps.build_changelog.outputs.changelog }}
           draft: false
           prerelease: false


### PR DESCRIPTION
- Add the pyinstaller bin to release artifacts
- Checked with June and we are going to remove the .deb files from the release artifacts. The deb workflows sttill exist and if users want then they can get the deb files from the build-all workflow too.