### PR TITLE
Add GDDR FW version to FW table

### DIFF
--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -121,6 +121,7 @@ class TestSnapshot:
             assert "eth_fw" in firmwares
             assert "dm_bl_fw" in firmwares
             assert "dm_app_fw" in firmwares
+            assert "gddr_fw" in firmwares
 
     def test_limits_fields(self, snapshot):
         """Test if fields are present in limits."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,11 @@
 
 import pytest
 
-from tt_smi.tt_smi_utils import get_board_type, convert_signed_16_16_to_float
+from tt_smi.tt_smi_utils import (
+    get_board_type,
+    convert_signed_16_16_to_float,
+    hex_to_semver_gddr_fw,
+)
 
 class TestGetBoardType:
     @pytest.mark.parametrize(
@@ -78,3 +82,19 @@ class TestDataFormatting:
     def test_convert_signed_16_16_to_float(self, raw, expected):
         """Test converting signed 16.16 fixed-point number to float."""
         assert convert_signed_16_16_to_float(raw) == pytest.approx(expected)
+
+
+class TestHexToSemverGddrFw:
+    """BH GDDR/MRISC FW: major = high 16 bits, minor = low 16 bits; display major.minor."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (0x2000F, "2.15"),
+            (0x0002000F, "2.15"),
+            (0x0, "N/A"),
+            (0xFFFFFFFF, "N/A"),
+        ],
+    )
+    def test_hex_to_semver_gddr_fw(self, raw, expected):
+        assert hex_to_semver_gddr_fw(raw) == expected

--- a/tt_smi/constants.py
+++ b/tt_smi/constants.py
@@ -97,6 +97,7 @@ BH_TELEMETRY_LIST = [
     "TAG_DDR_SPEED",
     "TAG_ETH_FW_VERSION",
     "TAG_DDR_FW_VERSION",
+    "GDDR_FW_VERSION",  # TAG_GDDR_FW_VERSION for UMD(telemetry tag 25); BH GDDR/MRISC FW
     "TAG_BM_APP_FW_VERSION",
     "TAG_BM_BL_FW_VERSION",
     "TAG_FLASH_BUNDLE_VERSION",
@@ -139,6 +140,7 @@ FW_LIST_SNAPSHOT = [
     "eth_fw",
     "dm_bl_fw",
     "dm_app_fw",
+    "gddr_fw",
 ]
 
 FW_LIST_GUI = [
@@ -146,6 +148,7 @@ FW_LIST_GUI = [
     "cm_fw",
     "eth_fw",
     "dm_app_fw",
+    "gddr_fw",
 ]
 
 DEV_INFO_LIST = [
@@ -210,6 +213,7 @@ FIRMWARES_TABLE_HEADER = [
     "CM FW Version",
     "ETH FW Version",
     "DM App Version",
+    "GDDR FW Version",
 ]
 
 PCI_PROPERTIES = [

--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -240,6 +240,7 @@ class Firmwares(ElasticModel):
     dm_bl_fw: str
     dm_app_fw: str
     tt_flash_version: str
+    gddr_fw: str
 
 
 @optional

--- a/tt_smi/tt_smi_backend.py
+++ b/tt_smi/tt_smi_backend.py
@@ -27,6 +27,7 @@ from tt_smi.tt_smi_utils import (
     hex_to_date,
     hex_to_semver_eth,
     hex_to_semver_m3_fw,
+    hex_to_semver_gddr_fw,
     hex_to_semver_eth_wh,
     get_board_type,
     convert_signed_16_16_to_float,
@@ -805,4 +806,14 @@ class TTSMIBackend:
                     fw_versions[field] = "N/A"
                 else:
                     fw_versions[field] = hex_to_semver_m3_fw(int(val, 16))
+            elif field == "gddr_fw":
+                if self.use_umd:
+                    val = self.smbus_telem_info[board_num].get("GDDR_FW_VERSION")
+                else:
+                    # TODO: Need to add GDDR FW tag into luwen
+                    val = None
+                if val is None or not self.is_blackhole(board_num):
+                    fw_versions[field] = "N/A"
+                else:
+                    fw_versions[field] = hex_to_semver_gddr_fw(int(val, 16))
         return fw_versions

--- a/tt_smi/tt_smi_utils.py
+++ b/tt_smi/tt_smi_utils.py
@@ -66,6 +66,19 @@ def hex_to_semver_m3_fw(hexsemver: int):
     return f"{major}.{minor}.{patch}.{ver}"
 
 
+def hex_to_semver_gddr_fw(raw: int) -> str:
+    """
+    Blackhole GDDR/MRISC FW telemetry (TAG_GDDR_FW_VERSION; UMD key GDDR_FW_VERSION): upper 16 bits = major,
+    lower 16 bits = minor (same decoding as UMD for BH). Display as major.minor only.
+    Example: 0x2000f -> 2.15
+    """
+    if raw == 0 or raw == 0xFFFFFFFF:
+        return "N/A"
+    major = (raw >> 16) & 0xFFFF
+    minor = raw & 0xFFFF
+    return f"{major}.{minor}"
+
+
 def get_board_type(board_id: str) -> str:
     """
     Get board type from board ID string.


### PR DESCRIPTION
<img width="926" height="193" alt="image" src="https://github.com/user-attachments/assets/9b151d0e-c3bc-4b8e-8352-b120631797e9" />

Added GDDR FW into the smi table for BH devices