### PR TITLE
Add tt-smi colors for formatting

### DIFF
--- a/tt_smi/backend.py
+++ b/tt_smi/backend.py
@@ -20,7 +20,7 @@ from rich import get_console
 from rich.syntax import Syntax
 from typing import Any, Dict, List, Optional, Union
 from rich.progress import track
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.colors import CMD_LINE_COLOR
 from pyluwen import PciChip
 from tt_smi.utils import (
     LOG_FOLDER,

--- a/tt_smi/colors.py
+++ b/tt_smi/colors.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from tt_tools_common.ui_common.themes import CMD_LINE_COLOR as _CMD_LINE_COLOR
+
+if not sys.stdout.isatty():
+    for attr in dir(_CMD_LINE_COLOR):
+        if not attr.startswith("_"):
+            setattr(_CMD_LINE_COLOR, attr, "")
+
+CMD_LINE_COLOR = _CMD_LINE_COLOR

--- a/tt_smi/device_input.py
+++ b/tt_smi/device_input.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.colors import CMD_LINE_COLOR
 
 DEV_TENSTORRENT_PREFIX = "/dev/tenstorrent/"
 PCI_BDF_FULL_RE = re.compile(

--- a/tt_smi/reset.py
+++ b/tt_smi/reset.py
@@ -13,7 +13,7 @@ import sys
 import time
 from typing import List
 
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.colors import CMD_LINE_COLOR
 from tt_tools_common.reset_common.wh_reset import WHChipReset
 from tt_tools_common.reset_common.bh_reset import BHChipReset
 from tt_tools_common.reset_common.chip_reset import ChipReset, IoctlResetFlags
@@ -37,12 +37,12 @@ from tt_tools_common.utils_common.tools_utils import (
 
 
 def timed_wait(seconds):
-    print("\033[93mWaiting for {} seconds: 0\033[0m".format(seconds), end='')
+    print("{}Waiting for {} seconds: 0{}".format(CMD_LINE_COLOR.YELLOW, seconds, CMD_LINE_COLOR.ENDC), end='')
     sys.stdout.flush()
 
     for i in range(1, seconds + 1):
         time.sleep(1)
-        print("\r\033[93mWaiting for {} seconds: {}\033[0m".format(seconds, i), end='')
+        print("\r{}Waiting for {} seconds: {}{}".format(CMD_LINE_COLOR.YELLOW, seconds, i, CMD_LINE_COLOR.ENDC), end='')
         sys.stdout.flush()
     print()
 

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -16,7 +16,7 @@ import argparse
 from importlib.metadata import version
 
 from tt_umd import TopologyDiscovery
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.colors import CMD_LINE_COLOR
 from tt_tools_common.utils_common.tools_utils import detect_chips_with_callback
 from tt_tools_common.utils_common.system_utils import get_driver_version
 

--- a/tt_smi/utils.py
+++ b/tt_smi/utils.py
@@ -10,7 +10,7 @@ import sys
 import glob
 from importlib.metadata import version
 
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.colors import CMD_LINE_COLOR
 
 from tt_smi import constants
 


### PR DESCRIPTION
**Description**

The `tt-smi` repository contains hardcoded ANSI color strings (or a static color mapping) for console logging, but it doesn't check whether the current output stream is an interactive terminal (TTY) before applying them. When output is redirected, the stream is no longer a terminal, and then the redirected output contains these special characters.

**Color handling improvements:**

* Added a new `tt_smi/colors.py` module that wraps `CMD_LINE_COLOR` and disables color codes if stdout is not a TTY.
* Updated all files (`backend.py`, `device_input.py`, `reset.py`, `tt_smi.py`, `utils.py`) to import `CMD_LINE_COLOR` from `tt_smi.colors` instead of `tt_tools_common.ui_common.themes`.
**Code usage updates:**

* Modified the `timed_wait` function in `tt_smi/reset.py` to use `CMD_LINE_COLOR.YELLOW` and `CMD_LINE_COLOR.ENDC` for colored output, ensuring consistent and TTY-safe color usage.