### PR TITLE
Refactor - moved UI, reset and util functionality out of tt-tools-common into tt-smi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 dependencies = [
   'distro>=1.8.0',
+  'psutil>=5.9.0',
   'elasticsearch>=8.11.0',
   'pydantic>=1.2',
   'tt_tools_common~=1.6.0',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,8 +6,71 @@ import pytest
 from tt_smi.utils import (
     get_board_type,
     convert_signed_16_16_to_float,
+    get_size,
+    get_host_info,
+    get_host_compatibility_info,
+    init_logging,
     hex_to_semver_gddr_fw,
+    is_driver_version_at_least,
 )
+
+class TestDriverVersion:
+    def test_is_driver_version_at_least(self):
+        assert is_driver_version_at_least("1.34.0", "1.34.0")
+        assert is_driver_version_at_least("2.0.0", "1.34.0")
+        assert not is_driver_version_at_least("1.34.0", "1.35.0")
+        assert is_driver_version_at_least("2.7.1-pre", "2.7.0")
+
+    def test_is_driver_version_at_least_no_driver(self):
+        with pytest.raises(ValueError, match="No Tenstorrent driver"):
+            is_driver_version_at_least(None, "2.0.0")
+
+
+class TestGetSize:
+    def test_get_size_bytes(self):
+        assert get_size(500) == "500.00 B"
+        assert get_size(1253656) == "1.20 MB"
+
+    def test_get_size_zero(self):
+        assert get_size(0) == "0.00 B"
+
+
+class TestGetHostInfo:
+    def test_get_host_info_keys(self):
+        info = get_host_info()
+        assert set(info.keys()) == {
+            "OS",
+            "Distro",
+            "Kernel",
+            "Hostname",
+            "Platform",
+            "Python",
+            "Memory",
+            "Driver",
+        }
+        assert info["Driver"].startswith("TT-KMD ")
+
+
+class TestGetHostCompatibilityInfo:
+    def test_get_host_compatibility_info_keys(self):
+        info = get_host_compatibility_info()
+        assert set(info.keys()) == {
+            "OS",
+            "Distro",
+            "Kernel",
+            "Hostname",
+            "Python",
+            "Memory",
+            "Driver",
+        }
+
+
+class TestInitLogging:
+    def test_init_logging_creates_folder(self, tmp_path):
+        log_dir = tmp_path / "tt_smi_logs"
+        init_logging(str(log_dir))
+        assert log_dir.is_dir()
+
 
 class TestGetBoardType:
     @pytest.mark.parametrize(

--- a/tt_smi/backend.py
+++ b/tt_smi/backend.py
@@ -20,7 +20,7 @@ from rich import get_console
 from rich.syntax import Syntax
 from typing import Any, Dict, List, Optional, Union
 from rich.progress import track
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.ui_utils import CMD_LINE_COLOR
 from pyluwen import PciChip
 from tt_smi.utils import (
     LOG_FOLDER,
@@ -32,8 +32,10 @@ from tt_smi.utils import (
     get_board_type,
     convert_signed_16_16_to_float,
     dict_from_public_attrs,
+    get_host_info,
     get_host_software_versions,
-    get_fw_bundle_version
+    get_fw_bundle_version,
+    init_logging,
 )
 from tt_umd import (
     TTDevice,
@@ -43,11 +45,6 @@ from tt_umd import (
     SmBusArcTelemetryReader,
     ARCH,
 )
-from tt_tools_common.utils_common.system_utils import (
-    get_host_info,
-)
-from tt_tools_common.utils_common.tools_utils import init_logging
-
 class TTSMIBackend:
     """
     TT-SMI backend class that encompasses all chip objects on host.

--- a/tt_smi/common_style.css
+++ b/tt_smi/common_style.css
@@ -1,0 +1,225 @@
+/*
+SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/* TT COLOURS */
+$red: #f04f5e;
+$green: #1eb57d;
+$yellow: #ffd10a;
+$purple: #786bb0;
+$orange: darkorange;
+$gray: ansi_bright_black;
+
+/* Principal style */
+* {
+  color: $yellow;
+  scrollbar-color: $yellow;
+  scrollbar-color-active: white;
+  scrollbar-color-hover: white;
+  scrollbar-background: $green;
+  scrollbar-background-active: $green;
+  scrollbar-background-hover: $green;
+  border-title-align: left;
+  border-title-color: $yellow;
+  border-title-style: bold;
+}
+
+/* Header and footer style */
+
+TTHeader,
+TTFooter {
+  height: 3;
+  text-style: bold;
+  outline: solid $green;
+}
+
+TTHeader {
+  dock: top;
+}
+
+TTFooter {
+  dock: bottom;
+}
+
+/* DataTable style */
+
+DataTable {
+  padding: 1 2;
+  color: $green;
+  border: solid $green;
+  height: 1fr;
+  text-align: center;
+}
+
+DataTable>.datatable--header {
+  text-style: bold;
+  text-align: center;
+  background: white 0%;
+  /* Make transparent */
+}
+
+DataTable>.datatable--cursor {
+  background: $yellow;
+  color: black;
+}
+
+DataTable>.datatable--fixed-cursor {
+  background: $yellow;
+  color: white;
+}
+
+DataTable>.datatable--header-cursor {
+  background: $yellow;
+  color: white;
+}
+
+DataTable>.datatable--header-hover {
+  background: 0%;
+  color: white 0%;
+}
+
+DataTable>.datatable--hover {
+  background: $yellow 60%;
+  color: white;
+}
+
+/* TTMenu Style */
+
+TTMenu,
+TTCompatibilityMenu,
+TTHostCompatibilityMenu {
+  padding: 1 1;
+  border: solid $green;
+  color: $green;
+}
+/*
+/*
+TTCompatibilityMenu {
+  height: 9;
+}
+*/
+
+/* TTConfirmBox Style */
+
+TTConfirmBox {
+  align: center middle;
+}
+
+#dialog {
+  padding: 1 2;
+  grid-size: 2;
+  grid-gutter: 1 2;
+  grid-rows: 1fr 3;
+  width: 30%;
+  height: 25%;
+  border: solid $green;
+  background: $surface;
+}
+
+#question {
+  column-span: 2;
+  height: 1fr;
+  width: 1fr;
+  content-align: center middle;
+}
+
+Button {
+  width: 100%;
+  background: $yellow;
+  color: white;
+}
+
+Button:hover,
+Button:focus {
+  background: $red;
+  color: white;
+  text-style: bold;
+}
+
+Footer {
+  background: $green;
+  color: white;
+  dock: bottom;
+  text-style: bold;
+  height: 1;
+}
+
+Footer>.footer--highlight {
+  background: $accent-darken-1;
+}
+
+Footer>.footer--highlight-key {
+  background: $yellow;
+  text-style: bold;
+  color: white;
+}
+
+Footer>.footer--key {
+  text-style: bold;
+  background: $accent-darken-2;
+}
+
+
+Input>.input--placeholder {
+  color: gray;
+}
+
+TabPane {
+  width: 100%;
+  /* Enable scrolling on tabs */
+  overflow: auto hidden;
+}
+
+/* Help Menu box styling*/
+TTHelperMenuBox {
+  align: center middle;
+}
+
+#help_menu_box {
+  padding: 1 2;
+  width: 110;
+  height: 30;
+  border: solid $green;
+  background: $surface;
+  color: white;
+
+}
+
+MarkdownH1 {
+  background: $accent-darken-2;
+  border: wide $background;
+  content-align: center middle;
+  padding: 1;
+  text-style: bold;
+  color: white;
+}
+
+MarkdownTableContent {
+  width: 100%;
+  height: auto;
+
+}
+
+MarkdownTableContent>.markdown-table--header {
+  text-style: bold;
+}
+
+Switch>.switch--slider {
+  color: $red;
+  background: red 12%;
+}
+
+
+Switch.-on>.switch--slider {
+  color: $green;
+  background: $green 15%;
+}
+
+TTHealthMenu,
+TTTextMenu,
+TTTestOutput {
+  padding: 1 2;
+  border: solid $green;
+  color: $green;
+}

--- a/tt_smi/device_input.py
+++ b/tt_smi/device_input.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.ui_utils import CMD_LINE_COLOR
 
 DEV_TENSTORRENT_PREFIX = "/dev/tenstorrent/"
 PCI_BDF_FULL_RE = re.compile(

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -4,7 +4,6 @@
 """Textual TUI: layout, tables, telemetry worker, and Rich formatting for TT-SMI."""
 
 import time
-from importlib.resources import files
 from importlib.metadata import version
 from typing import List, Tuple, Union
 
@@ -15,18 +14,17 @@ from textual.widgets import Footer, TabbedContent
 from textual.containers import Container, Vertical
 from textual.worker import get_current_worker, Worker, WorkerState
 
-from tt_tools_common.ui_common.themes import create_tt_tools_theme
-from tt_tools_common.ui_common.widgets import (
+from . import constants
+from .backend import TTSMIBackend
+from .ui_utils import (
     TTHeader,
     TTDataTable,
     TTHostCompatibilityMenu,
     TTHelperMenuBox,
+    create_tt_tools_theme,
+    get_common_style_css_path,
 )
-from tt_tools_common.utils_common.system_utils import get_host_compatibility_info
-
-from . import constants
-from .backend import TTSMIBackend
-from .utils import hex_to_semver_eth, hex_to_semver_m3_fw
+from .utils import get_host_compatibility_info, hex_to_semver_eth, hex_to_semver_m3_fw
 
 TextualKeyBindings = List[Tuple[str, str, str]]
 
@@ -44,16 +42,7 @@ class TTSMI(App):
         ("3", "tab_three", "Firmware tab"),
     ]
 
-    try:
-        common_style_file_path = files("tt_tools_common.ui_common").joinpath(
-            "common_style.css"
-        )
-    except Exception:
-        raise Exception(
-            "Cannot find common_style.css file, please make sure tt_tools_common lib is installed correctly."
-        )
-
-    CSS_PATH = [f"{common_style_file_path}", "tt_smi_style.css"]
+    CSS_PATH = [str(get_common_style_css_path()), "tt_smi_style.css"]
 
     def __init__(
         self,

--- a/tt_smi/reset.py
+++ b/tt_smi/reset.py
@@ -13,11 +13,10 @@ import sys
 import time
 from typing import List
 
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.ui_utils import CMD_LINE_COLOR
 from tt_tools_common.reset_common.wh_reset import WHChipReset
 from tt_tools_common.reset_common.bh_reset import BHChipReset
-from tt_tools_common.reset_common.chip_reset import ChipReset, IoctlResetFlags
-from tt_smi.utils import get_dev_id_from_bdf
+from tt_smi.utils import get_dev_id_from_bdf, IoctlResetFlags, reset_device_ioctl
 from tt_smi.constants import get_default_discovery_options
 from tt_smi.device_input import SmiDeviceInput, SmiDeviceTargetKind
 from pyluwen import (
@@ -321,7 +320,7 @@ def glx_6u_trays_reset(
         CMD_LINE_COLOR.ENDC,
     )
     for interface_id in user_reset_ids:
-        if not ChipReset().reset_device_ioctl(interface_id, IoctlResetFlags.USER_RESET):
+        if not reset_device_ioctl(interface_id, IoctlResetFlags.USER_RESET):
             print(
                 CMD_LINE_COLOR.YELLOW,
                 f"Warning: USER_RESET did not complete for device {interface_id}. Continuing...",
@@ -347,7 +346,7 @@ def glx_6u_trays_reset(
         CMD_LINE_COLOR.ENDC,
     )
     for interface_id in post_reset_ids:
-        if not ChipReset().reset_device_ioctl(interface_id, IoctlResetFlags.POST_RESET):
+        if not reset_device_ioctl(interface_id, IoctlResetFlags.POST_RESET):
             print(
                 CMD_LINE_COLOR.RED,
                 f"Error: POST_RESET failed for device {interface_id}.",

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -16,13 +16,11 @@ import argparse
 from importlib.metadata import version
 
 from tt_umd import TopologyDiscovery
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+from tt_smi.ui_utils import CMD_LINE_COLOR
 from tt_tools_common.utils_common.tools_utils import detect_chips_with_callback
-from tt_tools_common.utils_common.system_utils import get_driver_version
-
 from tt_smi import constants
 from tt_smi.backend import TTSMIBackend
-from tt_smi.utils import check_is_galaxy, is_vm
+from tt_smi.utils import check_is_galaxy, get_driver_version, is_vm
 from tt_smi.reset import (
     pci_board_reset,
     glx_6u_trays_reset,

--- a/tt_smi/ui_utils.py
+++ b/tt_smi/ui_utils.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TT-SMI UI helpers: terminal colors, Textual theme, widgets, and packaged CSS.
+"""
+
+from datetime import datetime
+from importlib.resources import files
+from typing import Dict, List, Tuple, Union
+
+from rich.panel import Panel
+from rich.style import Style
+from rich.table import Table
+from rich.text import Text
+from textual.app import ComposeResult, RenderResult
+from textual.containers import Container, ScrollableContainer
+from textual.coordinate import Coordinate
+from textual.screen import ModalScreen
+from textual.widget import Widget
+from textual.widgets import DataTable, Markdown
+from textual.widgets.data_table import CellDoesNotExist
+
+
+def create_color_scheme(color_system: str):
+    if color_system == "truecolor":
+        return {
+            "red": "#f04f5e",
+            "green": "#1eb57d",
+            "yellow": "#ffd10a",
+            "purple": "#786bb0",
+            "orange": "dark_orange",
+            "white": "white",
+            "grey": "bright_black",
+        }
+    if color_system == "256":
+        return {
+            "red": "red1",
+            "green": "dark_cyan",
+            "yellow": "gold1",
+            "purple": "medium_purple3",
+            "orange": "dark_orange",
+            "white": "white",
+            "grey": "bright_black",
+        }
+    if color_system == "standard":
+        return {
+            "red": "red",
+            "green": "green",
+            "yellow": "bright_yellow",
+            "purple": "magenta",
+            "orange": "bright_red",
+            "white": "white",
+            "grey": "bright_black",
+        }
+    return None
+
+
+class CMD_LINE_COLOR:
+    PURPLE = "\033[95m"
+    BLUE = "\033[94m"
+    GREEN = "\033[92m"
+    RED = "\033[91m"
+    ENDC = "\033[0m"
+    YELLOW = "\033[93m"
+
+
+def create_tt_tools_theme():
+    """Return tt-smi Textual Rich theme styles."""
+    tt_colors = create_color_scheme("truecolor")
+
+    return {
+        "yellow_bold": Style(color=tt_colors["yellow"], bold=True),
+        "orange_italic": Style(color=tt_colors["orange"], italic=True),
+        "yellow_italic": Style(color=tt_colors["yellow"], italic=True),
+        "light_green_bold": Style(color="#B0FC38", bold=True),
+        "red_bold": Style(color=tt_colors["red"], bold=True),
+        "gray": Style(color=tt_colors["grey"]),
+        "text_green": Style(color=tt_colors["green"]),
+        "warning": Style(color=tt_colors["red"]),
+        "attention": Style(color=tt_colors["orange"]),
+        "green_bold": Style(color=tt_colors["green"], bold=True),
+    }
+
+
+def get_common_style_css_path():
+    """Return path to packaged common_style.css for Textual CSS_PATH."""
+    return files("tt_smi").joinpath("common_style.css")
+
+
+class TTHeader(Widget):
+    """A custom header widget for TT-SMI."""
+
+    def __init__(self, app_name: str, app_version: str) -> None:
+        super().__init__()
+        self.app_name = app_name
+        self.app_version = app_version
+
+    def on_mount(self) -> None:
+        self.set_interval(1, callback=self.refresh)
+
+    def render(self) -> RenderResult:
+        grid = Table.grid(expand=True, padding=(0, 1), pad_edge=True)
+        grid.add_column(justify="left", ratio=0.25)
+        grid.add_column(justify="center", ratio=0.5)
+        grid.add_column(justify="right", ratio=0.25)
+
+        version = f"Version {self.app_version}"
+        app_name = self.app_name
+        date = datetime.now().strftime("%b %d %Y %I:%M:%S %p")
+
+        grid.add_row(version, app_name, date)
+
+        return Panel(grid)
+
+
+class TTDataTable(ScrollableContainer):
+    """A custom container with a DataTable for TT-SMI."""
+
+    def __init__(
+        self, title: str, header: List[str] = None, id: str = None, **kwargs
+    ) -> None:
+        super().__init__(id=id)
+        self.border_title = title
+        self._title = title
+        self.header = header
+        self.dt = self.config_dt(**kwargs)
+
+    def style_header(self):
+        for i, header_text in enumerate(self.header):
+            self.header[i] = Text(header_text, justify="center", style="underline")
+
+    def config_dt(self, **kwargs) -> DataTable:
+        dt = DataTable(id=self.id + "_table", **kwargs)
+        dt.zebra_stripes = False
+        dt.cursor_type = "cell"
+        dt.border_title = self._title
+
+        if self.header:
+            self.style_header()
+            dt.add_columns(*self.header)
+
+        return dt
+
+    def update_data(self, rows: List[str]) -> None:
+        for i, row in enumerate(rows):
+            for j, val in enumerate(row):
+                try:
+                    self.dt.update_cell_at(
+                        coordinate=Coordinate(column=j, row=i), value=val
+                    )
+                except CellDoesNotExist:
+                    self.dt.clear()
+                    self.dt.add_rows(rows)
+
+    def compose(self) -> ComposeResult:
+        container = ScrollableContainer(self.dt, id=self.id)
+        yield container
+
+
+class TTHostCompatibilityMenu(Container):
+    """
+    Host info menu with compatibility notes (str = OK, tuple = warning + recommendation).
+    """
+
+    def __init__(self, id: str, title: str, data: Dict[str, Union[str, Tuple]]) -> None:
+        super().__init__(id=id)
+        self.data = data
+        self.justify_width = max([len(k) for k in self.data.keys()]) + 1
+
+        fully_compatible = all(isinstance(value, str) for value in self.data.values())
+        if fully_compatible:
+            self.border_title = title + " (Fully Compatible)"
+        else:
+            self.border_title = title + " (Config Warning!)"
+            self.styles.border_title_color = "red"
+            self.border_subtitle = "* Recommended Config"
+            self.styles.border_subtitle_color = "red"
+
+    def render(self) -> RenderResult:
+        text = Text()
+        for key, value in self.data.items():
+            line_leader = Text("* ")
+            if isinstance(value, str):
+                k = Text(
+                    f"{key.ljust(self.justify_width)}" + ": ",
+                    style=Style(color="#ffd10a", bold=True),
+                )
+                v = Text(f"{value}\n")
+                text.append_text(line_leader).append_text(k).append_text(v)
+            elif isinstance(value, tuple):
+                k = Text(
+                    f"{key.ljust(self.justify_width)}" + ": ",
+                    style=Style(color="#ffd10a", bold=True),
+                )
+                v_1 = Text(f"{value[0]}\n")
+                v_2 = Text(
+                    f"{' ' * (self.justify_width)}  * {value[1]}\n",
+                    style=Style(color="dark_orange"),
+                )
+                text.append_text(line_leader).append_text(k).append_text(
+                    v_1
+                ).append_text(v_2)
+        text.rstrip()
+
+        return text
+
+
+class TTHelperMenuBox(ModalScreen):
+    """Modal help screen with markdown content."""
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("escape", "esc_screen", "Escape the open screen"),
+        ("h", "help", "Quit the help box"),
+    ]
+
+    def __init__(self, text: str, theme: dict = None) -> None:
+        super().__init__()
+        self.text = text
+        self.theme = theme or {}
+
+    def compose(self) -> ComposeResult:
+        yield Markdown(self.text, id="help_menu_box")
+
+    async def action_quit(self) -> None:
+        self.app.pop_screen()
+
+    async def action_esc_screen(self) -> None:
+        self.app.pop_screen()
+
+    async def action_help(self) -> None:
+        self.app.pop_screen()

--- a/tt_smi/utils.py
+++ b/tt_smi/utils.py
@@ -8,14 +8,190 @@ Utility functions and constants for tt-smi (hex conversion, board type, logging 
 import os
 import sys
 import glob
+import fcntl
+import struct
+import platform
+from enum import IntEnum
 from importlib.metadata import version
+from typing import Dict, Tuple, Union
 
-from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
+import distro
+import psutil
+
+from tt_smi.ui_utils import CMD_LINE_COLOR
 
 from tt_smi import constants
 
 
 LOG_FOLDER = os.path.expanduser("~/tt_smi_logs/")
+
+TENSTORRENT_IOCTL_MAGIC = 0xFA
+TENSTORRENT_IOCTL_RESET_DEVICE = (TENSTORRENT_IOCTL_MAGIC << 8) | 6
+
+
+class IoctlResetFlags(IntEnum):
+    RESTORE_STATE = 0
+    RESET_PCIE_LINK = 1
+    CONFIG_WRITE = 2
+    USER_RESET = 3
+    ASIC_RESET = 4
+    ASIC_DMC_RESET = 5
+    POST_RESET = 6
+
+
+def reset_device_ioctl(interface_id: int, flags: int) -> bool:
+    """
+    Issue TENSTORRENT_IOCTL_RESET_DEVICE on /dev/tenstorrent/{interface_id}.
+
+    Returns True if the driver reports success (result == 0).
+    """
+    dev_path = f"/dev/tenstorrent/{interface_id}"
+    # O_APPEND signals to KMD 2.6.0+ that we are power-aware, skipping power state
+    # initialization that could worsen a hung device.
+    dev_fd = os.open(dev_path, os.O_RDWR | os.O_CLOEXEC | os.O_APPEND)
+    try:
+        reset_device_in_struct = "II"
+        reset_device_out_struct = "II"
+        reset_device_struct = reset_device_in_struct + reset_device_out_struct
+
+        input_size_bytes = struct.calcsize(reset_device_in_struct)
+        output_size_bytes = struct.calcsize(reset_device_out_struct)
+
+        reset_device_buf = bytearray(
+            struct.pack(reset_device_struct, output_size_bytes, flags, 0, 0)
+        )
+        fcntl.ioctl(dev_fd, TENSTORRENT_IOCTL_RESET_DEVICE, reset_device_buf)
+
+        output_buf = reset_device_buf[input_size_bytes:]
+        _, result = struct.unpack(reset_device_out_struct, output_buf)
+        return result == 0
+    finally:
+        os.close(dev_fd)
+
+
+def get_driver_version() -> Union[str, None]:
+    """Return the installed Tenstorrent KMD version from sysfs, or None if unavailable."""
+    try:
+        with open("/sys/module/tenstorrent/version", "r", encoding="utf-8") as f:
+            return f.readline().rstrip()
+    except OSError:
+        return None
+
+
+def _parse_version_string(version_str: str) -> Tuple[int, int, int]:
+    """
+    Parse a version string into (major, minor, patch).
+
+    Handles SemVer-like formats including pre-release identifiers and build metadata,
+    e.g. "1.34", "1.34.0", "1.34.1-alpha", "1.2.3+build456", "1.4.0-rc1+build42".
+    """
+    if not version_str:
+        raise ValueError("Version string cannot be empty")
+
+    core_version_str = version_str.split("+")[0]
+    main_version_part = core_version_str.split("-")[0]
+    parts = main_version_part.split(".")
+
+    if not parts or not parts[0]:
+        raise ValueError(f"Invalid version format: {version_str}")
+
+    try:
+        major = int(parts[0])
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        patch = int(parts[2]) if len(parts) > 2 else 0
+    except ValueError as e:
+        raise ValueError(f"Version parts must be integers: {version_str}") from e
+
+    return major, minor, patch
+
+
+def is_driver_version_at_least(current_version: str, minimum_version: str) -> bool:
+    """Return True if current_version >= minimum_version."""
+    if current_version is None:
+        raise ValueError(
+            "No Tenstorrent driver detected! Please install the driver using tt-kmd: "
+            "https://github.com/tenstorrent/tt-kmd"
+        )
+
+    return _parse_version_string(current_version) >= _parse_version_string(
+        minimum_version
+    )
+
+
+def get_size(size_bytes: int, suffix: str = "B") -> str:
+    """Scale bytes to human-readable size (e.g. 1253656 -> '1.20MB')."""
+    factor = 1024
+    for unit in ["", "K", "M", "G", "T", "P"]:
+        if size_bytes < factor:
+            return f"{size_bytes:.2f} {unit}{suffix}"
+        size_bytes /= factor
+    return "N/A"
+
+
+def get_host_info() -> dict:
+    """Return host OS, distro, kernel, memory, Python, and TT-KMD driver info."""
+    uname = platform.uname()
+    svmem = psutil.virtual_memory()
+    driver_version = get_driver_version()
+
+    return {
+        "OS": uname.system,
+        "Distro": distro.name(pretty=True),
+        "Kernel": uname.release,
+        "Hostname": uname.node,
+        "Platform": uname.machine,
+        "Python": platform.python_version(),
+        "Memory": get_size(svmem.total),
+        "Driver": "TT-KMD " + (driver_version or ""),
+    }
+
+
+def get_host_compatibility_info() -> Dict[str, Union[str, Tuple]]:
+    """
+    Return host info with system compatibility notes.
+
+    Values are str if compatible, or (current, recommended) if not.
+    """
+    host_info = get_host_info()
+    checklist = {}
+    full_os = f"{host_info['OS']} ({host_info['Platform']})"
+
+    if host_info["OS"] == "Linux":
+        checklist["OS"] = full_os
+    else:
+        checklist["OS"] = (full_os, "Linux (x86_64)")
+
+    if distro.id() == "ubuntu":
+        distro_version = float(".".join(distro.version_parts()[:2]))
+        if distro_version >= 22:
+            checklist["Distro"] = host_info["Distro"]
+        else:
+            checklist["Distro"] = (host_info["Distro"], "22.04 or 24.04")
+    else:
+        checklist["Distro"] = (host_info["Distro"], "Ubuntu 22.04 or 24.04")
+
+    checklist["Kernel"] = host_info["Kernel"]
+    checklist["Hostname"] = host_info["Hostname"]
+    checklist["Python"] = host_info["Python"]
+
+    if psutil.virtual_memory().total >= 32 * 1e9:
+        checklist["Memory"] = host_info["Memory"]
+    else:
+        checklist["Memory"] = (host_info["Memory"], "32GB+")
+
+    if get_driver_version():
+        checklist["Driver"] = host_info["Driver"]
+    else:
+        checklist["Driver"] = (host_info["Driver"], "TT-KMD v1.27+")
+
+    return checklist
+
+
+def init_logging(log_folder: str) -> None:
+    """Create log folder if it does not exist."""
+    if not os.path.isdir(log_folder):
+        os.mkdir(log_folder)
+
 
 def hex_to_date(hexdate: int, include_time=True):
     """Converts a date given in hex from format 0xYMDDHHMM to string YYYY-MM-DD HH:MM"""


### PR DESCRIPTION

- Cleanup as part of ongoing effort to depreciate tt-tools-common
- Moved general util functions, UI functions and reset out of tt-tools-common
- Left luwen chip detect and classify functions in tt-smi, since that is still currently shared with tt-flash