### PR TITLE
Add Latest Releases sidebar box

### DIFF
--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -6,12 +6,13 @@
 import time
 from importlib.resources import files
 from importlib.metadata import version
-from typing import List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
+from rich.style import Style
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches
-from textual.widgets import Footer, TabbedContent
+from textual.widgets import Footer, ProgressBar, Static, TabbedContent
 from textual.containers import Container, Vertical
 from textual.worker import get_current_worker, Worker, WorkerState
 
@@ -26,7 +27,127 @@ from tt_tools_common.utils_common.system_utils import get_host_compatibility_inf
 
 from . import constants
 from .backend import TTSMIBackend
+from .latest_releases import (
+    DEFAULT_MAX_ATTEMPTS,
+    RELEASE_SPECS,
+    ReleaseSpec,
+    fetch_all,
+    get_installed_all,
+    version_tuple,
+)
 from .utils import hex_to_semver_eth, hex_to_semver_m3_fw
+
+
+class LatestReleasesBox(Container):
+    """Sidebar box showing the latest published version of each tt-stack package.
+
+    Renders a ProgressBar while fetches are in-flight, then swaps to a list of
+    versions. If every fetch fails (e.g. no internet), the list stays empty
+    and the box just shows its border + title.
+    """
+
+    def __init__(self, id: str, title: str) -> None:
+        super().__init__(id=id)
+        self._base_title = title
+        self.border_title = title
+        self._versions: Dict[str, Optional[str]] = {}
+        # Specs in this dict are "checkable" (we know how to ask the host).
+        # Absence means "not checkable" → no glyph. Value of None means
+        # "checkable but not installed in PATH" → ✗.
+        self._installed: Dict[str, Optional[str]] = {}
+        self._key_width = max(len(s.name) for s in RELEASE_SPECS) + 1
+
+    def compose(self) -> ComposeResult:
+        yield ProgressBar(
+            total=len(RELEASE_SPECS), show_eta=False, id="latest_releases_progress"
+        )
+        yield Static("", id="latest_releases_list")
+
+    def on_mount(self) -> None:
+        self.query_one("#latest_releases_list", Static).display = False
+
+    def record(self, spec: ReleaseSpec, version: Optional[str]) -> None:
+        """One fetch completed. Stash the result and advance the progress bar."""
+        self._versions[spec.name] = version
+        self.query_one("#latest_releases_progress", ProgressBar).advance(1)
+
+    def set_installed(self, installed: Dict[str, Optional[str]]) -> None:
+        """Record installed-version lookups for the checkable specs."""
+        self._installed = installed
+
+    def set_attempt(self, attempt: int, max_attempts: int) -> None:
+        """Surface a retry indicator in the border title (e.g. 'attempt 2/3')."""
+        self.border_title = f"{self._base_title} (attempt {attempt}/{max_attempts})"
+        self.styles.border_title_color = "yellow"
+        # border_title is reactive and calls refresh(), but the Container
+        # chrome doesn't always redraw on its own — force it.
+        self.refresh()
+
+    def finalize(self) -> None:
+        """All fetches done. Swap the progress bar out for the version list."""
+        self.border_title = self._base_title
+        self.styles.border_title_color = None
+        self.query_one("#latest_releases_progress", ProgressBar).display = False
+        list_widget = self.query_one("#latest_releases_list", Static)
+        if any(v is not None for v in self._versions.values()):
+            list_widget.update(self._render_versions())
+        else:
+            list_widget.update(self._render_error())
+        list_widget.display = True
+        self.refresh()
+
+    def _row_status(
+        self, spec_name: str, latest: Optional[str]
+    ) -> Tuple[str, Optional[Style], str, Optional[Style]]:
+        """Return (glyph, glyph_style, value_text, value_style) for one row.
+
+        The value column shows "installed → latest" for the outdated case so
+        users see exactly what bump is available; everything else just shows
+        the latest version (or "—" if it's unknown).
+        """
+        muted = Style(color="grey50")
+        if spec_name not in self._installed:
+            # Not checkable on this host.
+            if latest is None:
+                return ("", None, "—", muted)
+            return ("", None, latest, None)
+
+        installed = self._installed[spec_name]
+        if installed is None:
+            # Checkable but not installed.
+            if latest is None:
+                return ("✗", Style(color="red"), "—", muted)
+            return ("✗", Style(color="red"), latest, None)
+
+        if latest is None:
+            # We have installed but couldn't fetch latest.
+            return ("", None, "—", muted)
+
+        if version_tuple(installed) >= version_tuple(latest):
+            return ("✓", Style(color="green"), latest, None)
+
+        return ("↑", Style(color="yellow"), f"{installed} → {latest}", Style(color="yellow"))
+
+    def _render_versions(self) -> Text:
+        text = Text()
+        for spec in RELEASE_SPECS:
+            ver = self._versions.get(spec.name)
+            glyph, glyph_style, val_text, val_style = self._row_status(spec.name, ver)
+            leader = Text(f"{glyph} " if glyph else "  ", style=glyph_style)
+            key = Text(
+                f"{spec.name.ljust(self._key_width)}: ",
+                style=Style(color="#ffd10a", bold=True),
+            )
+            val = Text(f"{val_text}\n", style=val_style)
+            text.append_text(leader).append_text(key).append_text(val)
+        text.rstrip()
+        return text
+
+    def _render_error(self) -> Text:
+        return Text(
+            "Failed to fetch latest releases.\nCheck your network connection.",
+            style=Style(color="red"),
+        )
 
 TextualKeyBindings = List[Tuple[str, str, str]]
 
@@ -85,10 +206,24 @@ class TTSMI(App):
         yield TTHeader(self.app_name, self.app_version)
         with Container(id="app_grid"):
             with Vertical(id="left_col"):
-                yield TTHostCompatibilityMenu(
+                host_data = get_host_compatibility_info()
+                host_info_widget = TTHostCompatibilityMenu(
                     id="host_info",
                     title="Host Info",
-                    data=get_host_compatibility_info(),
+                    data=host_data,
+                )
+                # TTHostCompatibilityMenu is a Container that draws via render()
+                # rather than child widgets, so textual's height: auto collapses
+                # to 0 and the default height: 1fr stretches it to fill the
+                # column. Pin to actual content height: one row per entry (two
+                # for tuple-valued entries that show a recommendation), plus 2
+                # border + 2 padding.
+                content_rows = sum(2 if isinstance(v, tuple) else 1 for v in host_data.values())
+                host_info_widget.styles.height = content_rows + 4
+                yield host_info_widget
+                yield LatestReleasesBox(
+                    id="latest_releases",
+                    title="Latest Releases",
                 )
             with TabbedContent(
                 "Information (1)", "Telemetry (2)", "FW Version (3)", id="tab_container"
@@ -129,6 +264,31 @@ class TTSMI(App):
 
         left_sidebar = self.query_one("#left_col")
         left_sidebar.display = self.show_sidebar
+
+        self.run_worker(
+            self.fetch_latest_releases,
+            thread=True,
+            exit_on_error=False,
+            name="latest_releases_thread",
+        )
+
+    def fetch_latest_releases(self) -> None:
+        """Worker: fetch latest GitHub release tags and push them to the box."""
+        try:
+            box = self.query_one("#latest_releases", LatestReleasesBox)
+        except NoMatches:
+            return
+
+        def on_done(spec: ReleaseSpec, version: Optional[str]) -> None:
+            self.call_from_thread(box.record, spec, version)
+
+        def on_attempt(attempt: int) -> None:
+            self.call_from_thread(box.set_attempt, attempt, DEFAULT_MAX_ATTEMPTS)
+
+        fetch_all(timeout=5.0, on_done=on_done, on_attempt=on_attempt)
+        installed = get_installed_all()
+        self.call_from_thread(box.set_installed, installed)
+        self.call_from_thread(box.finalize)
 
     def update_telem_table(self) -> None:
         """Update telemetry table"""

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -51,9 +51,9 @@ class LatestReleasesBox(Container):
         self._base_title = title
         self.border_title = title
         self._versions: Dict[str, Optional[str]] = {}
-        # Specs in this dict are "checkable" (we know how to ask the host).
-        # Absence means "not checkable" → no glyph. Value of None means
-        # "checkable but not installed in PATH" → ✗.
+        # Specs in this dict are "checkable" (we know how to ask the host);
+        # a None value means "not installed". A status glyph only renders
+        # when an installed version is known.
         self._installed: Dict[str, Optional[str]] = {}
         self._key_width = max(len(s.name) for s in RELEASE_SPECS) + 1
 
@@ -106,18 +106,12 @@ class LatestReleasesBox(Container):
         the latest version (or "—" if it's unknown).
         """
         muted = Style(color="grey50")
-        if spec_name not in self._installed:
-            # Not checkable on this host.
+        installed = self._installed.get(spec_name)
+        if installed is None:
+            # Not checkable on this host, or not installed: no status glyph.
             if latest is None:
                 return ("", None, "—", muted)
             return ("", None, latest, None)
-
-        installed = self._installed[spec_name]
-        if installed is None:
-            # Checkable but not installed.
-            if latest is None:
-                return ("✗", Style(color="red"), "—", muted)
-            return ("✗", Style(color="red"), latest, None)
 
         if latest is None:
             # We have installed but couldn't fetch latest.

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -185,6 +185,7 @@ class TTSMI(App):
         backend: TTSMIBackend = None,
         snapshot: bool = False,
         show_sidebar: bool = True,
+        offline: bool = False,
     ) -> None:
         """Initialize the textual app."""
         super().__init__()
@@ -193,6 +194,7 @@ class TTSMI(App):
         self.backend = backend
         self.snapshot = snapshot
         self.show_sidebar = show_sidebar
+        self.offline = offline
         self.result_filename = result_filename
         self.text_theme = create_tt_tools_theme()
         self.telem_worker = None
@@ -221,10 +223,11 @@ class TTSMI(App):
                 content_rows = sum(2 if isinstance(v, tuple) else 1 for v in host_data.values())
                 host_info_widget.styles.height = content_rows + 4
                 yield host_info_widget
-                yield LatestReleasesBox(
-                    id="latest_releases",
-                    title="Latest Releases",
-                )
+                if not self.offline:
+                    yield LatestReleasesBox(
+                        id="latest_releases",
+                        title="Latest Releases",
+                    )
             with TabbedContent(
                 "Information (1)", "Telemetry (2)", "FW Version (3)", id="tab_container"
             ):
@@ -265,12 +268,13 @@ class TTSMI(App):
         left_sidebar = self.query_one("#left_col")
         left_sidebar.display = self.show_sidebar
 
-        self.run_worker(
-            self.fetch_latest_releases,
-            thread=True,
-            exit_on_error=False,
-            name="latest_releases_thread",
-        )
+        if not self.offline:
+            self.run_worker(
+                self.fetch_latest_releases,
+                thread=True,
+                exit_on_error=False,
+                name="latest_releases_thread",
+            )
 
     def fetch_latest_releases(self) -> None:
         """Worker: fetch latest GitHub release tags and push them to the box."""

--- a/tt_smi/latest_releases.py
+++ b/tt_smi/latest_releases.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetches the latest published GitHub release tag for tt-stack packages.
+
+Each package has a tag pattern with a named "version" group; only releases
+whose tag matches the pattern are considered. This mirrors the renovate
+filter rules used by infra (allowedVersions / extractVersion).
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ReleaseSpec:
+    name: str
+    repo: str
+    tag_pattern: "re.Pattern[str]"
+    # cli=None means there's no PATH-based check for this package (firmware,
+    # metalium image, etc.). tt-kmd has no CLI but is checkable via sysfs, so
+    # we leave cli=None and special-case it in get_installed_version.
+    cli: Optional[str] = None
+
+
+RELEASE_SPECS: List[ReleaseSpec] = [
+    ReleaseSpec("tt-kmd",             "tenstorrent/tt-kmd",             re.compile(r"^ttkmd-?(?P<version>\d+\.\d+\.\d+)$")),
+    ReleaseSpec("tt-smi",             "tenstorrent/tt-smi",             re.compile(r"^v?(?P<version>\d+\.\d+\.\d+)$"),       cli="tt-smi"),
+    ReleaseSpec("tt-flash",           "tenstorrent/tt-flash",           re.compile(r"^v?(?P<version>\d+\.\d+\.\d+)$"),       cli="tt-flash"),
+    ReleaseSpec("tt-system-firmware", "tenstorrent/tt-system-firmware", re.compile(r"^v?(?P<version>19\.\d+\.\d+)$")),
+    ReleaseSpec("tt-metal",           "tenstorrent/tt-metal",           re.compile(r"^v?(?P<version>0\.\d+\.\d+)$")),
+    ReleaseSpec("tt-installer",       "tenstorrent/tt-installer",       re.compile(r"^v?(?P<version>\d+\.\d+\.\d+)$")),
+]
+
+
+def is_checkable(spec: ReleaseSpec) -> bool:
+    """Whether we can determine 'installed or not' for this spec via the host."""
+    return spec.name == "tt-kmd" or spec.cli is not None
+
+
+def _read_kmd_version() -> Optional[str]:
+    try:
+        with open("/sys/module/tenstorrent/version") as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
+
+def _cli_version(cli: str) -> Optional[str]:
+    if shutil.which(cli) is None:
+        return None
+    try:
+        result = subprocess.run(
+            [cli, "--version"], capture_output=True, text=True, timeout=2
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    output = (result.stdout or "") + (result.stderr or "")
+    m = re.search(r"\d+\.\d+\.\d+", output)
+    return m.group(0) if m else None
+
+
+def get_installed_version(spec: ReleaseSpec) -> Optional[str]:
+    """Look up the locally-installed version of a checkable package.
+
+    Returns the version string, or None if checkable but not installed. Caller
+    should gate on is_checkable() before reading the absence-of-key as "missing".
+    """
+    if spec.name == "tt-kmd":
+        return _read_kmd_version()
+    if spec.cli is not None:
+        return _cli_version(spec.cli)
+    return None
+
+
+def get_installed_all() -> Dict[str, Optional[str]]:
+    """Best-effort installed-version lookup for every checkable spec.
+
+    Returns {package_name: version_or_None}, only for specs where we have a
+    way to check. Specs not in the returned dict are "not checkable" (e.g.
+    tt-system-firmware, tt-metal) and should render without a status glyph.
+    """
+    return {
+        spec.name: get_installed_version(spec)
+        for spec in RELEASE_SPECS
+        if is_checkable(spec)
+    }
+
+
+def version_tuple(v: str) -> Tuple[int, ...]:
+    """Best-effort semver-ish tuple for comparison. Non-numeric parts are skipped."""
+    parts = []
+    for p in v.split("."):
+        try:
+            parts.append(int(p))
+        except ValueError:
+            break
+    return tuple(parts)
+
+
+def _fetch_latest_matching(spec: ReleaseSpec, timeout: float) -> Optional[str]:
+    """Return the version string of the newest release matching spec, or None."""
+    url = f"https://api.github.com/repos/{spec.repo}/releases?per_page=100"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "tt-smi",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            releases = json.loads(resp.read())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError):
+        return None
+
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        m = spec.tag_pattern.match(release.get("tag_name", ""))
+        if m:
+            return m.group("version")
+    return None
+
+
+DEFAULT_MAX_ATTEMPTS = 3
+
+
+def _fetch_batch(
+    specs: List[ReleaseSpec], timeout: float
+) -> Dict[str, Optional[str]]:
+    """Run one parallel pass over `specs`. Returns {name: version_or_None}."""
+    results: Dict[str, Optional[str]] = {}
+    if not specs:
+        return results
+    with ThreadPoolExecutor(max_workers=len(specs)) as pool:
+        futures = {
+            pool.submit(_fetch_latest_matching, spec, timeout): spec for spec in specs
+        }
+        for fut in as_completed(futures):
+            spec = futures[fut]
+            try:
+                results[spec.name] = fut.result()
+            except Exception:
+                results[spec.name] = None
+    return results
+
+
+def fetch_all(
+    timeout: float = 5.0,
+    on_done: Optional[Callable[[ReleaseSpec, Optional[str]], None]] = None,
+    on_attempt: Optional[Callable[[int], None]] = None,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> Dict[str, Optional[str]]:
+    """Fetch latest versions for every spec, retrying any that come back None.
+
+    Each attempt runs the remaining failed specs in parallel. `on_done` fires
+    exactly once per spec, when its version is known (success) or has exhausted
+    all attempts (final None). `on_attempt(n)` fires at the start of attempts
+    where n > 1 so callers can surface a retry indicator; it is not called for
+    the first attempt.
+    """
+    pending = list(RELEASE_SPECS)
+    final: Dict[str, Optional[str]] = {}
+    for attempt in range(1, max_attempts + 1):
+        if attempt > 1 and on_attempt is not None:
+            try:
+                on_attempt(attempt)
+            except Exception:
+                pass
+
+        round_results = _fetch_batch(pending, timeout)
+
+        next_pending: List[ReleaseSpec] = []
+        for spec in pending:
+            version = round_results.get(spec.name)
+            if version is not None or attempt == max_attempts:
+                final[spec.name] = version
+                if on_done is not None:
+                    try:
+                        on_done(spec, version)
+                    except Exception:
+                        pass
+            else:
+                next_pending.append(spec)
+        pending = next_pending
+        if not pending:
+            break
+    return final

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -83,6 +83,12 @@ def parse_args():
         help="Run in compact mode, hiding the sidebar and other static elements",
     )
     parser.add_argument(
+        "--offline",
+        default=False,
+        action="store_true",
+        help="Do not access the network; hides the Latest Releases box",
+    )
+    parser.add_argument(
         "-r",
         "--reset",
         metavar="TARGETS",
@@ -202,6 +208,7 @@ def tt_smi_main(backend: TTSMIBackend, args):
         snapshot=args.snapshot,
         result_filename=args.filename,
         show_sidebar=not args.compact,
+        offline=args.offline,
     )
     tt_smi_app.run()
 

--- a/tt_smi/tt_smi_style.css
+++ b/tt_smi/tt_smi_style.css
@@ -59,6 +59,23 @@ TTTestOutput {
   color: $green;
 }
 
+LatestReleasesBox {
+  padding: 1 1;
+  border: solid $green;
+  color: $green;
+  height: auto;
+}
+
+LatestReleasesBox ProgressBar {
+  width: 100%;
+  height: 1;
+}
+
+LatestReleasesBox Static {
+  width: 100%;
+  height: auto;
+}
+
 #settings_menu_box {
   padding: 1 1;
   grid-size: 2 5;


### PR DESCRIPTION
Adds a new box under the existing Host Info compatibility menu that
shows the latest published GitHub release version of each tt-stack
package (tt-kmd, tt-smi, tt-flash, tt-system-firmware, tt-metal,
tt-installer). The version-extraction and allowed-tag rules mirror the
renovate config used by infra (e.g. firmware is filtered to 19.x,
metalium to 0.x, kmd strips the ttkmd- prefix).

On launch a background worker fetches all six releases from the GitHub
API in parallel with a 5s per-request timeout, advancing a ProgressBar
in the box as each one completes. When the fetch finishes the bar is
replaced with a list of versions; failures show as "—". If every fetch
fails (e.g. no internet), the list is hidden and the box renders empty.

No on-disk cache: re-fetches on every launch.
