### PR TITLE
Add updated p100 dram training check

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from tt_smi.utils import (
     convert_signed_16_16_to_float,
     hex_to_semver_gddr_fw,
     is_driver_version_at_least,
+    p100_dram_training_passed,
 )
 
 class TestDriverVersion:
@@ -111,3 +112,45 @@ class TestHexToSemverGddrFw:
     )
     def test_hex_to_semver_gddr_fw(self, raw, expected):
         assert hex_to_semver_gddr_fw(raw) == expected
+
+
+def _p100_dram_status(*, harvested: int = None, fail_training: int = None, fail_bist: int = None) -> int:
+    """Build DDR_STATUS for P100 tests: all channels pass except optional overrides."""
+    status = 0x55555555
+    if harvested is not None:
+        status &= ~((1 << (2 * harvested)) | (1 << (16 + 2 * harvested)))
+    if fail_training is not None:
+        status |= 1 << (2 * fail_training + 1)
+        status &= ~(1 << (2 * fail_training))
+    if fail_bist is not None:
+        status |= 1 << (17 + 2 * fail_bist)
+        status &= ~(1 << (16 + 2 * fail_bist))
+    return status
+
+
+class TestP100DramTrainingPassed:
+    @pytest.mark.parametrize(
+        "dram_status,expected",
+        [
+            # 7 active channels + GDDR 2 harvested (real P100 example)
+            (0x55455545, True),
+            # Harvested slot can be any of the 8 channels
+            (_p100_dram_status(harvested=0), True),
+            (_p100_dram_status(harvested=7), True),
+            # All 8 channels trained — valid for non-P100, not the P100 7+1 layout
+            (0x55555555, False),
+            # Two harvested channels
+            (0x54455545, False),
+            (_p100_dram_status(harvested=0, fail_training=1), False),
+            # Training error on an active channel
+            (_p100_dram_status(harvested=2, fail_training=0), False),
+            # BIST failure on an active channel
+            (_p100_dram_status(harvested=2, fail_bist=5), False),
+            # Partial pass: training complete but BIST never ran
+            (0x55455555, False),
+            # No harvested channel (incomplete training on one slot)
+            (0x55455540, False),
+        ],
+    )
+    def test_p100_dram_training_passed(self, dram_status, expected):
+        assert p100_dram_training_passed(dram_status) is expected

--- a/tt_smi/backend.py
+++ b/tt_smi/backend.py
@@ -33,7 +33,8 @@ from tt_smi.utils import (
     convert_signed_16_16_to_float,
     dict_from_public_attrs,
     get_host_software_versions,
-    get_fw_bundle_version
+    get_fw_bundle_version,
+    p100_dram_training_passed,
 )
 from tt_umd import (
     TTDevice,
@@ -493,7 +494,12 @@ class TTSMIBackend:
                 # [31] - BIST failed GDDR 7
                 if dram_status == 0x55555555:
                     return True
-                return False
+                # check if its p100 and if so, check if the training passed
+                match get_board_type(self.get_board_id(board_num)):
+                    case "p100a":
+                        return p100_dram_training_passed(dram_status)
+                    case _:
+                        return False
             else:
                 # Pre-19.7.0.3 DDR Status in BH is a 16-bit field with the following layout:
                 #  [0] - Training complete GDDR 0

--- a/tt_smi/utils.py
+++ b/tt_smi/utils.py
@@ -176,6 +176,54 @@ def hex_to_semver_gddr_fw(raw: int) -> str:
     return f"{major}.{minor}"
 
 
+def p100_dram_training_passed(dram_status: int) -> bool:
+    """
+    Check if DRAM training passed for P100.
+
+    P100 may ship with one harvested GDDR channel (any of the 8). Pass when
+    exactly 7 channels report training+BIST success (0b01 in each 2-bit field),
+    and one channel reports all status bits clear (0b00 — absent/harvested slot).
+    """
+    passing_channels = 0
+    harvested_channels = 0
+
+    for channel in range(8):
+        # Per-channel DDR_STATUS layout (FW 19.7.3.0+):
+        #   bits [2i+1:2i]     - [training error | training complete]
+        #   bits [17+2i:16+2i] - [BIST failed    | BIST complete]
+        #
+        # 0b01 = success, 0b10 = failure, 0b00 = not run (harvested on P100)
+        training_complete = bool(dram_status & (1 << (2 * channel)))
+        training_error = bool(dram_status & (1 << (2 * channel + 1)))
+        bist_complete = bool(dram_status & (1 << (16 + 2 * channel)))
+        bist_failed = bool(dram_status & (1 << (17 + 2 * channel)))
+
+        if (
+            training_complete
+            and not training_error
+            and bist_complete
+            and not bist_failed
+        ):
+            # Active channel: trained and passed BIST (0b01 / 0b01).
+            passing_channels += 1
+        elif (
+            not training_complete
+            and not training_error
+            and not bist_complete
+            and not bist_failed
+        ):
+            # Harvested channel: firmware never ran training/BIST (0b00 / 0b00).
+            harvested_channels += 1
+            if harvested_channels > 1:
+                return False
+        else:
+            # Real failure: error/fail bit set, or partial/incomplete state.
+            return False
+
+    # P100 expects 7 active GDDR channels and 1 harvested slot.
+    return passing_channels == 7 and harvested_channels == 1
+
+
 def get_board_type(board_id: str) -> str:
     """
     Get board type from board ID string.


### PR DESCRIPTION
- p100 has one channel harvested and that channel is not fixed. Hence added a util to check that exactly one channel is "broken"
- Added unit test to check the fix

tested on one p100
<img width="1050" height="182" alt="image" src="https://github.com/user-attachments/assets/f79bca31-5ba3-4ca7-b950-a94a1267ca94" />
