### PR TITLE
Remove galaxy 6U tray reset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,4 +66,4 @@ jobs:
 
       - name: Run hardware tests
         run: |
-          pytest tests/ -v -m requires_hardware -m "not requires_galaxy"
+          pytest tests/ -v -m requires_hardware

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ uv run pre-commit install
 tt-smi can be used as a GUI (`tt-smi`) or CLI (`tt-smi -s`) to display system information and Tenstorrent device telemetry, and it can be used to reset Tenstorrent devices (`tt-smi -r`).
 
 ```
-tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto] [-glx_reset_tray {1,2,3,4}] [-glx_list_tray_to_device] [--no_reinit]
+tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_list_tray_to_device] [--no_reinit]
 ```
 
 ## Getting Help
@@ -105,7 +105,7 @@ Running tt-smi with the ```-h, --help``` flag displays the help text.
 
 ```
 $ tt-smi -h
-usage: tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto] [-glx_reset_tray {1,2,3,4}] [-glx_list_tray_to_device] [--no_reinit] [--use_luwen]
+usage: tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_list_tray_to_device] [--no_reinit] [--use_luwen]
 
 Tenstorrent System Management Interface (TT-SMI) is a command line utility to interact with all Tenstorrent devices on host. The main objective of TT-SMI is to provide a simple and easy-to-use
 interface to display devices, device telemetry, and system information. TT-SMI is also used to issue board-level resets.
@@ -122,12 +122,6 @@ options:
   -r [TARGETS ...], --reset [TARGETS ...]
                         Reset targets: UMD logical IDs, PCI BDFs (e.g. 0000:0a:00.0), or /dev/tenstorrent/<id>. Use -ls to list devices. Omit targets or use "all" to reset all devices. Do not mix types in one command.
   --snapshot_no_tty     Force no-tty behavior in the snapshot to stdout
-  -glx_reset, --galaxy_6u_trays_reset
-                        Reset all the ASICs on the galaxy host
-  -glx_reset_auto, --galaxy_6u_trays_reset_auto
-                        Reset all ASICs on the galaxy host, but do auto retries up to 3 times if reset fails
-  -glx_reset_tray {1,2,3,4}, --galaxy_6u_reset_tray {1,2,3,4}
-                        Reset a specific tray on the galaxy
   -glx_list_tray_to_device, --galaxy_6u_list_tray_to_device
                         List the mapping of devices to trays on the galaxy
   --no_reinit           Don't detect devices post reset
@@ -247,34 +241,9 @@ By default, the reset command will re-initialize the boards after reset. Use the
 
 ## Galaxy resets
 
-There are several options available for resetting Galaxy 6U trays.
-  - Use the `-r/--reset` argument and treat it like any other pcie card. Warning - Needs CPLD FW v1.16 or higher. 
-  - glx_reset: resets the galaxy, informs users if an Ethernet failure has been detected
-  - glx_reset_auto: same as -glx_reset, but resets up to 3 times if an Ethernet failure has been detected
-  - glx_reset_tray <tray_num>: performs reset on one galaxy tray. Tray number has to be between 1-4
+Use the `-r/--reset` argument on Galaxy systems and treat them like any other pcie card. Warning - Needs CPLD FW v1.16 or higher.
 
-### Full galaxy reset
-```
-tt-smi -glx_reset
- Resetting WH Galaxy trays with reset command...
-Executing command: sudo ipmitool raw 0x30 0x8B 0xF 0xFF 0x0 0xF
-Waiting for 30 seconds: 30
-Driver loaded
- Re-initializing boards after reset....
- Detected Chips: 32
- Re-initialized 32 boards after reset. Exiting...
-```
-### Tray reset
-```
-tt-smi -glx_reset_tray 3 --no_reinit
- Resetting WH Galaxy trays with reset command...
-Executing command: sudo ipmitool raw 0x30 0x8B 0x4 0xFF 0x0 0xF
-Waiting for 30 seconds: 30
-Driver loaded
- Re-initializing boards after reset....
- Exiting after galaxy reset without re-initializing chips.
-```
-To identify the correct tray number for resetting specific devices, users can run `tt-smi -glx_list_tray_to_device / --galaxy_6u_list_tray_to_device`. This command displays a mapping table that shows the relationship between tray numbers, tray bus IDs, and the corresponding PCI device IDs, making it easier to target the appropriate tray for reset operations. Note that this command should not be run in a virtual machine (VM) environment as it requires direct hardware access to the Galaxy system.
+To identify the tray for specific devices, users can run `tt-smi -glx_list_tray_to_device / --galaxy_6u_list_tray_to_device`. This command displays a mapping table that shows the relationship between tray numbers, tray bus IDs, and the corresponding PCI device IDs, making it easier to target the appropriate devices for reset operations. Note that this command should not be run in a virtual machine (VM) environment as it requires direct hardware access to the Galaxy system.
 
 ```
 $ tt-sml -glx_list_tray_to_device

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ optional-dependencies.test = [
 [tool.pytest.ini_options]
 markers = [
   "requires_hardware: marks tests as requiring Tenstorrent hardware",
-  "requires_galaxy: marks tests as requiring Galaxy hardware",
 ]
 
 [project.urls]

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -9,10 +9,7 @@ from pyluwen import pci_scan
 from tt_umd import PCIDevice
 from tt_smi.backend import TTSMIBackend
 from tt_smi.utils import get_dev_id_from_bdf
-from tt_smi.reset import (
-    pci_board_reset,
-    glx_6u_trays_reset,
-)
+from tt_smi.reset import pci_board_reset
 from tt_smi.device_input import (
     classify_single_input,
     parse_smi_device_input,
@@ -262,44 +259,5 @@ class TestPciDriverReset:
                 reinit=True,
                 use_umd=use_umd,
             )
-            post_reset_devices = redetect_devices(use_umd)
-            assert len(post_reset_devices) == len(pci_indices)
-
-
-@pytest.mark.requires_hardware
-@pytest.mark.requires_galaxy
-class TestGalaxyReset:
-    def test_glx_reset(self, reset_test_config):
-        """
-        Test galaxy 6U trays reset (invoked by tt-smi -glx_reset).
-
-        Passes if the reset is successful and the same number of devices are
-        detected before and after.
-        """
-        pci_indices, use_umd = reset_test_config
-        # Expect SystemExit with return code 0 on successful reset
-        with pytest.raises(SystemExit) as exc_info:
-            glx_6u_trays_reset(use_umd=use_umd)
-
-        assert exc_info.value.code == 0
-
-        post_reset_devices = redetect_devices(use_umd)
-        assert len(post_reset_devices) == len(pci_indices)
-
-    def test_glx_reset_stress(self, reset_test_config):
-        """
-        Test galaxy 6U trays reset NUM_RESETS_STRESS_TEST times in a row.
-
-        Passes if the resets are successful and the same number of devices are
-        detected before and after each reset.
-        """
-        pci_indices, use_umd = reset_test_config
-        for _ in range(NUM_RESETS_STRESS_TEST):
-            # Expect SystemExit with return code 0 on successful reset
-            with pytest.raises(SystemExit) as exc_info:
-                glx_6u_trays_reset(use_umd=use_umd)
-
-            assert exc_info.value.code == 0
-
             post_reset_devices = redetect_devices(use_umd)
             assert len(post_reset_devices) == len(pci_indices)

--- a/tt_smi/reset.py
+++ b/tt_smi/reset.py
@@ -170,13 +170,6 @@ def umd_pci_warm_reset(
         if info.subsystem_id in {0x35, 0x47}:
             is_galaxy = True
             break
-    if is_galaxy:
-        print(
-            CMD_LINE_COLOR.YELLOW,
-            "CPLD FW v1.16 or higher is required to use tt-smi -r on Galaxy systems.",
-            "If tt-smi -r fails, please continue to use tt-smi -glx_reset instead and contact your system administrator to request a CPLD update.",
-            CMD_LINE_COLOR.ENDC,
-        )
     secondary_bus_reset = should_use_secondary_bus_reset(is_galaxy)
 
     reset_indices = reset_input.value
@@ -256,14 +249,6 @@ def luwen_pci_reset(
             del chip
 
     is_galaxy = board_types <= {0x35, 0x47}
-    if is_galaxy:
-        print(
-            CMD_LINE_COLOR.YELLOW,
-            "CPLD FW v1.16 or higher is required to use tt-smi -r on Galaxy systems.",
-            "If tt-smi -r fails, please continue to use tt-smi -glx_reset instead and contact your system administrator to request a CPLD update.",
-            CMD_LINE_COLOR.ENDC,
-        )
-
     secondary_bus_reset = should_use_secondary_bus_reset(is_galaxy)
     if reset_wh_pci_idx:
         WHChipReset().full_lds_reset(

--- a/tt_smi/reset.py
+++ b/tt_smi/reset.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Reset-related functions for tt-smi: PCI board reset, galaxy 6U tray reset, and helpers.
+Reset-related functions for tt-smi: PCI board reset and helpers.
 
 Device-selection parsing for ``-r`` / ``--reset`` lives in
 :mod:`tt_smi.device_input`; this module focuses on the reset mechanism itself.
@@ -10,8 +10,6 @@ Device-selection parsing for ``-r`` / ``--reset`` lives in
 
 import os
 import sys
-import time
-from concurrent.futures import ThreadPoolExecutor
 from typing import List
 
 from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
@@ -21,16 +19,12 @@ from tt_smi.utils import (
     get_dev_id_from_bdf,
     get_driver_version,
     is_driver_version_at_least,
-    IoctlResetFlags,
-    reset_device_ioctl,
 )
 from tt_smi.constants import get_default_discovery_options
 from tt_smi.device_input import SmiDeviceInput, SmiDeviceTargetKind
 from pyluwen import (
     PciChip,
     pci_scan,
-    run_wh_ubb_ipmi_reset,
-    run_ubb_wait_for_driver_load,
 )
 from tt_umd import (
     WarmReset,
@@ -60,36 +54,6 @@ def should_use_secondary_bus_reset(is_galaxy: bool) -> bool:
         driver_version, MINIMUM_DRIVER_VERSION_GALAXY_SECONDARY_BUS_RESET
     )
 
-
-def parallel_reset_device_ioctl(device_ids: List[int], flag: int) -> List[int]:
-    """
-    Issue reset ioctl on each device in parallel.
-
-    Returns interface IDs where the ioctl did not complete successfully.
-    """
-    if not device_ids:
-        return []
-
-    def ioctl_one(interface_id: int) -> tuple[int, bool]:
-        return interface_id, reset_device_ioctl(interface_id, flag)
-
-    failed: List[int] = []
-    with ThreadPoolExecutor(max_workers=len(device_ids)) as pool:
-        for interface_id, ok in pool.map(ioctl_one, device_ids):
-            if not ok:
-                failed.append(interface_id)
-    return failed
-
-
-def timed_wait(seconds):
-    print("\033[93mWaiting for {} seconds: 0\033[0m".format(seconds), end='')
-    sys.stdout.flush()
-
-    for i in range(1, seconds + 1):
-        time.sleep(1)
-        print("\r\033[93mWaiting for {} seconds: {}\033[0m".format(seconds, i), end='')
-        sys.stdout.flush()
-    print()
 
 # Keep this function for now, but it's not used anywhere in the codebase. 
 # It is the check that is used in Funtest for Galaxy systems and we might need to reference it later.
@@ -129,33 +93,6 @@ def check_wh_galaxy_eth_link_status(devices):
                 CMD_LINE_COLOR.ENDC,
             )
         raise Exception("WH Galaxy Ethernet link errors detected!")
-
-def umd_ubb_wait_for_driver_load():
-    """
-    Wait for the driver to reload for UMD, try 100 times.
-    Similar to luwen's ubb_wait_for_driver_load but uses PCIDevice.enumerate_devices.
-    """
-    attempts = 0
-    expected_chip_count = 32
-
-    while attempts < 100:
-        device_count = 0
-        try:
-            devices = PCIDevice.enumerate_devices()
-            device_count = len(devices)
-            if device_count == expected_chip_count:
-                print(f"Driver loaded with {device_count} devices")
-                return
-        except Exception:
-            pass
-
-        print(f"Waiting for driver load ... {attempts} seconds (found {device_count} devices)")
-        time.sleep(1)
-        attempts += 1
-
-    raise Exception(
-        f"Driver not loaded with {expected_chip_count} devices after 100 seconds... giving up"
-    )
 
 def umd_pci_warm_reset(
     reset_input: SmiDeviceInput,
@@ -297,150 +234,3 @@ def pci_board_reset(
                 CMD_LINE_COLOR.ENDC,
             )
             sys.exit(1)
-
-
-def glx_6u_trays_reset(
-    reinit: bool = True,
-    ubb_num: str = "0xF",
-    dev_num: str = "0xFF",
-    op_mode: str = "0x0",
-    reset_time: str = "0xF",
-    print_status: bool = True,
-    use_umd: bool = False,
-):
-    """
-    Reset the WH asics on the galaxy systems with the following steps:
-    1. Perform USER_RESET ioctl on all chips
-    2. Reset the trays with ipmi command (or UMD warm reset)
-    3. Wait for 30s
-    4. Perform POST_RESET ioctl on all chips
-    5. Reinit all chips
-
-    Args:
-        reinit: Whether to reinitialize the chips after reset.
-        ubb_num: The UBB number to reset. 0x0~0xF (bit map)
-        dev_num: The device number to reset. 0x0~0xFF(bit map)
-        op_mode: The operation mode to use.
-        reset_time: The reset time to use. resolution 10ms (ex. 0xF => 15 => 150ms)
-        print_status: Whether to print out animations while detecting chips.
-        use_umd: Whether to use UMD (WarmReset.ubb_warm_reset) or pyluwen (run_wh_ubb_ipmi_reset)
-    """
-    # First, check if we're trying to do anything other than a full reset
-    if ubb_num != "0xF" or dev_num != "0xFF" or op_mode != "0x0" or reset_time != "0xF":
-        print(
-            CMD_LINE_COLOR.RED,
-            "Error: Galaxy 6U IPMI reset only supports full Galaxy reset ",
-            "(ubb_num=0xF, dev_num=0xFF, op_mode=0x0, reset_time=0xF)",
-            CMD_LINE_COLOR.ENDC,
-        )
-        sys.exit(1)
-    print(
-        CMD_LINE_COLOR.PURPLE,
-        "Resetting WH Galaxy trays with reset command...",
-        CMD_LINE_COLOR.ENDC,
-    )
-
-    if use_umd:
-        device_ids = list(PCIDevice.enumerate_devices())
-    else:
-        device_ids = pci_scan()
-
-    if should_use_secondary_bus_reset(True):
-        print(
-            CMD_LINE_COLOR.BLUE,
-            f"Issuing RESET_PCIE_LINK on {len(device_ids)} devices before IPMI reset...",
-            CMD_LINE_COLOR.ENDC,
-        )
-        for interface_id in parallel_reset_device_ioctl(
-            device_ids, IoctlResetFlags.RESET_PCIE_LINK
-        ):
-            print(
-                CMD_LINE_COLOR.YELLOW,
-                f"Warning: Secondary bus reset not completed for device /dev/tenstorrent/{interface_id}. Continuing...",
-                CMD_LINE_COLOR.ENDC,
-            )
-
-    print(
-        CMD_LINE_COLOR.BLUE,
-        f"Issuing USER_RESET on {len(device_ids)} devices before IPMI reset...",
-        CMD_LINE_COLOR.ENDC,
-    )
-    for interface_id in parallel_reset_device_ioctl(
-        device_ids, IoctlResetFlags.USER_RESET
-    ):
-        print(
-            CMD_LINE_COLOR.YELLOW,
-            f"Warning: USER_RESET did not complete for device /dev/tenstorrent/{interface_id}. Continuing...",
-            CMD_LINE_COLOR.ENDC,
-        )
-
-    # IPMI reset
-    if use_umd:
-        WarmReset.ubb_warm_reset(timeout_s=100.0)
-    else:
-        run_wh_ubb_ipmi_reset(ubb_num, dev_num, op_mode, reset_time)
-    timed_wait(30)
-    # This function waits for all 32 chips to reappear on the bus.
-    run_ubb_wait_for_driver_load()
-
-    # Issue POST_RESET ioctl on all devices after they reappear
-    if use_umd:
-        post_reset_ids = list(PCIDevice.enumerate_devices())
-    else:
-        post_reset_ids = pci_scan()
-    print(
-        CMD_LINE_COLOR.BLUE,
-        f"Issuing POST_RESET on {len(post_reset_ids)} devices after IPMI reset...",
-        CMD_LINE_COLOR.ENDC,
-    )
-    post_reset_failed = parallel_reset_device_ioctl(
-        post_reset_ids, IoctlResetFlags.POST_RESET
-    )
-    for interface_id in post_reset_failed:
-        print(
-            CMD_LINE_COLOR.RED,
-            f"Error: POST_RESET failed for device /dev/tenstorrent/{interface_id}.",
-            CMD_LINE_COLOR.ENDC,
-        )
-    if post_reset_failed:
-        sys.exit(1)
-
-    print(
-        CMD_LINE_COLOR.PURPLE,
-        "Re-initializing boards after reset....",
-        CMD_LINE_COLOR.ENDC,
-    )
-    if not reinit:
-        print(
-            CMD_LINE_COLOR.GREEN,
-            "Exiting after galaxy reset without re-initializing chips.",
-            CMD_LINE_COLOR.ENDC,
-        )
-        sys.exit(0)
-    try:
-        if use_umd:
-            options = get_default_discovery_options()
-            options.discover_remote_devices = False
-            options.wait_on_ethernet_link_training = False
-            _, devices = TopologyDiscovery.discover(options=options)
-            chip_count = len(devices)
-        else:
-            os.environ["RUST_BACKTRACE"] = "full"
-            chips = detect_chips_with_callback(
-                local_only=True, ignore_ethernet=True, print_status=print_status
-            )
-            chip_count = len(chips)
-    except Exception as e:
-        print(
-            CMD_LINE_COLOR.RED,
-            f"Error when re-initializing chips!\n {e}",
-            CMD_LINE_COLOR.ENDC,
-        )
-        sys.exit(1)
-
-    print(
-        CMD_LINE_COLOR.GREEN,
-        f"Re-initialized {chip_count} boards after reset. Exiting...",
-        CMD_LINE_COLOR.ENDC,
-    )
-    sys.exit(0)

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -23,10 +23,7 @@ from tt_smi.utils import get_driver_version
 from tt_smi import constants
 from tt_smi.backend import TTSMIBackend
 from tt_smi.utils import check_is_galaxy, is_vm
-from tt_smi.reset import (
-    pci_board_reset,
-    glx_6u_trays_reset,
-)
+from tt_smi.reset import pci_board_reset
 from tt_smi.device_input import parse_smi_device_input
 from tt_smi.frontend import TTSMI
 
@@ -108,30 +105,6 @@ def parse_args():
         default=False,
         action="store_true",
         help="Force no-tty behavior in the snapshot to stdout",
-    )
-    parser.add_argument(
-        "-glx_reset",
-        "--galaxy_6u_trays_reset",
-        default=False,
-        action="store_true",
-        help="Reset all the ASICs on the galaxy host",
-        dest="glx_reset",
-    )
-    parser.add_argument(
-        "-glx_reset_auto",
-        "--galaxy_6u_trays_reset_auto",
-        default=False,
-        action="store_true",
-        help="Reset all ASICs on the galaxy host, but do auto retries up to 3 times if reset fails",
-        dest="glx_reset_auto",
-    )
-    parser.add_argument(
-        "-glx_reset_tray",
-        "--galaxy_6u_reset_tray",
-        choices=["1", "2", "3", "4",],
-        default=None,
-        help="Reset a specific tray on the galaxy",
-        dest="glx_reset_tray",
     )
     parser.add_argument(
         "-glx_list_tray_to_device",
@@ -242,69 +215,6 @@ def main():
         reset_input = parse_smi_device_input(args.reset)
         pci_board_reset(reset_input, reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen, eth_train_skip=args.eth_train_skip)
         sys.exit(0)
-    # Handle ubb reset without backend
-    if args.glx_reset:
-        # Galaxy reset, without auto retries
-        try:
-            print(
-                CMD_LINE_COLOR.YELLOW,
-                "Hint: tt-smi -r is now supported on Galaxy 6U.",
-                CMD_LINE_COLOR.ENDC,
-            )
-            # reinit has to be enabled to detect devices post reset
-            glx_6u_trays_reset(reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen)
-        except Exception as e:
-            print(
-                CMD_LINE_COLOR.RED,
-                f"Error in resetting galaxy 6u trays!\n{e}\n Exiting...",
-                CMD_LINE_COLOR.ENDC,
-            )
-            sys.exit(1)
-    if args.glx_reset_auto:
-        # Galaxy reset with upto 3 auto retries
-        reset_try_number = 0
-        max_reset_try = 3
-        print(
-            CMD_LINE_COLOR.YELLOW,
-            f"This option will auto retry resetting galaxy 6u trays up to {max_reset_try} times if it fails.",
-            CMD_LINE_COLOR.ENDC,
-        )
-        while reset_try_number < max_reset_try:
-            print(
-                CMD_LINE_COLOR.YELLOW,
-                f"Trying reset ({reset_try_number+1}/{max_reset_try})...",
-                CMD_LINE_COLOR.ENDC,
-            )
-            try:
-                # Try to reset galaxy 6u trays
-                # reinit has to be enabled to detect devices post reset
-                glx_6u_trays_reset(reinit=True, print_status=is_tty, use_umd=not args.use_luwen)
-                break  # If reset was successful, break the loop
-            except Exception as e:
-                reset_try_number += 1
-                if reset_try_number < max_reset_try:
-                    print(
-                        CMD_LINE_COLOR.RED,
-                        f"Error in resetting galaxy 6u trays, resetting again...",
-                        CMD_LINE_COLOR.ENDC,
-                    )
-                else:
-                    print(
-                        CMD_LINE_COLOR.RED,
-                        f"Failed on last reset...exiting with error code 1",
-                        CMD_LINE_COLOR.ENDC,
-                    )
-                    sys.exit(1)
-
-        # All went well - exit
-        sys.exit(0)
-    if args.glx_reset_tray is not None:
-        print(
-            CMD_LINE_COLOR.RED,
-            f"Galaxy 6U tray reset is no longer supported. Please use tt-smi -glx_reset to reset all chips or tt-smi -r.",
-            CMD_LINE_COLOR.ENDC,
-        )
-        sys.exit(1)
 
     try:
         if not args.use_luwen:


### PR DESCRIPTION
## Summary

- Drop the yellow CPLD FW v1.16 warning printed by `tt-smi -r` on Galaxy
  systems.
- Remove the `-glx_reset`, `-glx_reset_auto`, and `-glx_reset_tray`
  flags along with `glx_6u_trays_reset` and its helpers
  (`timed_wait`, `umd_ubb_wait_for_driver_load`). Galaxy systems are
  now reset with `tt-smi -r` like any other device.
- `-glx_list_tray_to_device` is unaffected.
- Remove the now-unused `requires_galaxy` pytest marker and its CI
  exclusion, and update the README accordingly.

## Test plan

- Non-hardware parse tests are unchanged; hardware reset tests run in CI.
- Galaxy-specific tests (`TestGalaxyReset`) are removed with the
  functionality they covered.