### PR TITLE
Remove galaxy -glx_reset_tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ uv run pre-commit install
 tt-smi can be used as a GUI (`tt-smi`) or CLI (`tt-smi -s`) to display system information and Tenstorrent device telemetry, and it can be used to reset Tenstorrent devices (`tt-smi -r`).
 
 ```
-tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto] [-glx_reset_tray {1,2,3,4}] [-glx_list_tray_to_device] [--no_reinit]
+tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto] [-glx_list_tray_to_device] [--no_reinit]
 ```
 
 ## Getting Help
@@ -105,7 +105,7 @@ Running tt-smi with the ```-h, --help``` flag displays the help text.
 
 ```
 $ tt-smi -h
-usage: tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto] [-glx_reset_tray {1,2,3,4}] [-glx_list_tray_to_device] [--no_reinit] [--use_luwen]
+usage: tt-smi [-h] [-l] [-v] [-s] [-ls] [-f [snapshot filename]] [-c] [-r [TARGETS ...]] [--snapshot_no_tty] [-glx_reset] [-glx_reset_auto] [-glx_list_tray_to_device] [--no_reinit] [--use_luwen]
 
 Tenstorrent System Management Interface (TT-SMI) is a command line utility to interact with all Tenstorrent devices on host. The main objective of TT-SMI is to provide a simple and easy-to-use
 interface to display devices, device telemetry, and system information. TT-SMI is also used to issue board-level resets.
@@ -126,8 +126,6 @@ options:
                         Reset all the ASICs on the galaxy host
   -glx_reset_auto, --galaxy_6u_trays_reset_auto
                         Reset all ASICs on the galaxy host, but do auto retries up to 3 times if reset fails
-  -glx_reset_tray {1,2,3,4}, --galaxy_6u_reset_tray {1,2,3,4}
-                        Reset a specific tray on the galaxy
   -glx_list_tray_to_device, --galaxy_6u_list_tray_to_device
                         List the mapping of devices to trays on the galaxy
   --no_reinit           Don't detect devices post reset
@@ -251,7 +249,6 @@ There are several options available for resetting Galaxy 6U trays.
   - Use the `-r/--reset` argument and treat it like any other pcie card. Warning - Needs CPLD FW v1.16 or higher. 
   - glx_reset: resets the galaxy, informs users if an Ethernet failure has been detected
   - glx_reset_auto: same as -glx_reset, but resets up to 3 times if an Ethernet failure has been detected
-  - glx_reset_tray <tray_num>: performs reset on one galaxy tray. Tray number has to be between 1-4
 
 ### Full galaxy reset
 ```
@@ -264,17 +261,7 @@ Driver loaded
  Detected Chips: 32
  Re-initialized 32 boards after reset. Exiting...
 ```
-### Tray reset
-```
-tt-smi -glx_reset_tray 3 --no_reinit
- Resetting WH Galaxy trays with reset command...
-Executing command: sudo ipmitool raw 0x30 0x8B 0x4 0xFF 0x0 0xF
-Waiting for 30 seconds: 30
-Driver loaded
- Re-initializing boards after reset....
- Exiting after galaxy reset without re-initializing chips.
-```
-To identify the correct tray number for resetting specific devices, users can run `tt-smi -glx_list_tray_to_device / --galaxy_6u_list_tray_to_device`. This command displays a mapping table that shows the relationship between tray numbers, tray bus IDs, and the corresponding PCI device IDs, making it easier to target the appropriate tray for reset operations. Note that this command should not be run in a virtual machine (VM) environment as it requires direct hardware access to the Galaxy system.
+To identify the correct tray number for resetting specific devices, users can run `tt-smi -glx_list_tray_to_device / --galaxy_6u_list_tray_to_device`. This command displays a mapping table that shows the relationship between tray numbers, tray bus IDs, and the corresponding PCI device IDs, making it easier to target the appropriate devices for reset operations. Note that this command should not be run in a virtual machine (VM) environment as it requires direct hardware access to the Galaxy system.
 
 ```
 $ tt-sml -glx_list_tray_to_device

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -126,14 +126,6 @@ def parse_args():
         dest="glx_reset_auto",
     )
     parser.add_argument(
-        "-glx_reset_tray",
-        "--galaxy_6u_reset_tray",
-        choices=["1", "2", "3", "4",],
-        default=None,
-        help="Reset a specific tray on the galaxy",
-        dest="glx_reset_tray",
-    )
-    parser.add_argument(
         "-glx_list_tray_to_device",
         "--galaxy_6u_list_tray_to_device",
         default=False,
@@ -293,13 +285,6 @@ def main():
 
         # All went well - exit
         sys.exit(0)
-    if args.glx_reset_tray is not None:
-        print(
-            CMD_LINE_COLOR.RED,
-            f"Galaxy 6U tray reset is no longer supported. Please use tt-smi -glx_reset to reset all chips or tt-smi -r.",
-            CMD_LINE_COLOR.ENDC,
-        )
-        sys.exit(1)
 
     try:
         if not args.use_luwen:

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -246,11 +246,6 @@ def main():
     if args.glx_reset:
         # Galaxy reset, without auto retries
         try:
-            print(
-                CMD_LINE_COLOR.YELLOW,
-                "Hint: tt-smi -r is now supported on Galaxy 6U.",
-                CMD_LINE_COLOR.ENDC,
-            )
             # reinit has to be enabled to detect devices post reset
             glx_6u_trays_reset(reinit=not(args.no_reinit), print_status=is_tty, use_umd=not args.use_luwen)
         except Exception as e:


### PR DESCRIPTION
## Summary

- Drop the `-glx_reset` hint that `tt-smi -r` is supported on Galaxy
  6U.
- Remove the `-glx_reset_tray` flag. Per-tray reset was already a stub
  that exits with an error; this removes the flag and its README
  documentation.
- `-glx_reset`, `-glx_reset_auto`, and `-glx_list_tray_to_device`
  are unchanged.

## Test plan

- CI runs the existing reset tests; no tests covered the removed stub.