### PR TITLE
Add total board power to telemetry table and snapshot.

### DIFF
--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -104,6 +104,7 @@ class TestSnapshot:
             assert "voltage" in telemetry
             assert "current" in telemetry
             assert "power" in telemetry
+            assert "board_power" in telemetry
             assert "aiclk" in telemetry
             assert "asic_temperature" in telemetry
             assert "fan_speed" in telemetry
@@ -136,6 +137,7 @@ class TestSnapshot:
             assert "therm_trip_l1_limit" in limits
             assert "thm_limit" in limits
             assert "bus_peak_limit" in limits
+            assert "board_power_limit" in limits
 
     def test_snapshot_no_tty(self):
         """Test if the output from tt-smi -s --snapshot_no_tty can be parsed as json"""

--- a/tt_smi/backend.py
+++ b/tt_smi/backend.py
@@ -351,6 +351,13 @@ class TTSMIBackend:
             for telem_key in tag_collection:
                 telem_value = hex(telem_reader.read_entry(telem_key.value)) if telem_reader.is_entry_available(telem_key.value) else None
                 smbus_telem_dict[telem_key.name] = telem_value
+            # UMD TelemetryTag omits TAG_INPUT_POWER (54); read it by tag id.
+            if telem_reader.is_entry_available(constants.TAG_INPUT_POWER):
+                smbus_telem_dict["INPUT_POWER"] = hex(
+                    telem_reader.read_entry(constants.TAG_INPUT_POWER)
+                )
+            else:
+                smbus_telem_dict["INPUT_POWER"] = None
             return smbus_telem_dict
         
         pyluwen_chip = self.devices[board_num]
@@ -665,6 +672,10 @@ class TTSMIBackend:
             if self.smbus_telem_info[board_num]["TDP"] is not None
             else 0
         )
+        input_power = self.smbus_telem_info[board_num].get("INPUT_POWER")
+        board_power = (
+            f"{int(input_power, 16):5.1f}" if input_power is not None else "N/A"
+        )
         asic_temperature = (
             (
                 convert_signed_16_16_to_float(
@@ -690,6 +701,7 @@ class TTSMIBackend:
             "voltage": f"{voltage:4.2f}",
             "current": f"{current:5.1f}",
             "power": f"{power:5.1f}",
+            "board_power": board_power,
             "aiclk": f"{aiclk:4.0f}",
             "asic_temperature": f"{asic_temperature:4.1f}",
             "fan_speed": f"{fan_speed}",
@@ -705,6 +717,10 @@ class TTSMIBackend:
         else:
             voltage = 10000
         power = int(self.smbus_telem_info[board_num]["TDP"], 16) & 0xFFFF
+        input_power = self.smbus_telem_info[board_num].get("INPUT_POWER")
+        board_power = (
+            f"{int(input_power, 16):5.1f}" if input_power is not None else "N/A"
+        )
         asic_temperature = (
             int(self.smbus_telem_info[board_num]["ASIC_TEMPERATURE"], 16) & 0xFFFF
         ) / 16
@@ -722,6 +738,7 @@ class TTSMIBackend:
             "voltage": f"{voltage:4.2f}",
             "current": f"{current:5.1f}",
             "power": f"{power:5.1f}",
+            "board_power": board_power,
             "aiclk": f"{aiclk:4.0f}",
             "asic_temperature": f"{asic_temperature:4.1f}",
             "fan_speed": f"{fan_speed}",
@@ -783,6 +800,11 @@ class TTSMIBackend:
             elif field == "thm_limit":
                 thm_limits = self.smbus_telem_info[board_num].get("THM_LIMITS")
                 chip_limits[field] = f"{int(thm_limits, 16) & 0xFFFF:2.0f}" if thm_limits else 0
+            elif field == "board_power_limit":
+                board_power_limit = self.smbus_telem_info[board_num].get("BOARD_POWER_LIMIT")
+                chip_limits[field] = (
+                    f"{int(board_power_limit, 16):3.0f}" if board_power_limit else 0
+                )
             else:
                 chip_limits[field] = 0
         return chip_limits
@@ -818,6 +840,11 @@ class TTSMIBackend:
                 else:
                     thm_limits = 0
                 chip_limits[field] = f"{int(thm_limits, 16):2.0f}" if thm_limits else 0
+            elif field == "board_power_limit":
+                board_power_limit = self.smbus_telem_info[board_num].get("BOARD_POWER_LIMIT")
+                chip_limits[field] = (
+                    f"{int(board_power_limit, 16):3.0f}" if board_power_limit else 0
+                )
             else:
                 chip_limits[field] = 0
         return chip_limits

--- a/tt_smi/constants.py
+++ b/tt_smi/constants.py
@@ -116,6 +116,7 @@ TELEM_LIST = [
     "current",
     "aiclk",
     "power",
+    "board_power",
     "asic_temperature",
     "fan_speed",
     "heartbeat",
@@ -131,7 +132,11 @@ LIMITS = [
     "thm_limit",
     "bus_peak_limit",
     "fan_rpm_limit",
+    "board_power_limit",
 ]
+
+# FW TAG_INPUT_POWER; missing from UMD TelemetryTag as of tt-umd 0.9.8
+TAG_INPUT_POWER = 54
 
 # leaving this intact for the snapshot version of the firmware list 
 # Don't want to break any automations we have around the snapshot
@@ -205,6 +210,7 @@ TELEMETRY_TABLE_HEADER = [
     "Core Current (A)",
     "AICLK (MHz)",
     "Core Power (W)",
+    "Board Power (W)",
     "Core Temp (°C)",
     "Fan Speed (RPM)",
     "Heartbeat",

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -422,6 +422,34 @@ class TTSMI(App):
                             justify="center",
                         )
                     )
+                elif telem == "board_power":
+                    max_board_power = self.backend.chip_limits[board_num]["board_power_limit"]
+                    if val == "N/A":
+                        device_row.append(
+                            Text(
+                                f"{val}",
+                                style=self.text_theme["gray"],
+                                justify="center",
+                            )
+                            + Text(
+                                f"/ {max_board_power}" if max_board_power else "/ ---",
+                                style=self.text_theme["yellow_bold"] if max_board_power else self.text_theme["gray"],
+                                justify="center",
+                            )
+                        )
+                    else:
+                        device_row.append(
+                            Text(
+                                f"{val}",
+                                style=self.text_theme["text_green"] if float(val) < float(max_board_power) else self.text_theme["attention"],
+                                justify="center",
+                            )
+                            + Text(
+                                f"/ {max_board_power}" if max_board_power else "/ ---",
+                                style=self.text_theme["yellow_bold"] if max_board_power else self.text_theme["gray"],
+                                justify="center",
+                            )
+                        )
                 elif telem == "aiclk":
                     asic_fmax = self.backend.chip_limits[board_num]["asic_fmax"]
                     device_row.append(

--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -229,6 +229,7 @@ class Telemetry(ElasticModel):
     current: str
     aiclk: str
     power: str
+    board_power: str
     asic_temperature: str
 
 


### PR DESCRIPTION
Surface TAG_INPUT_POWER against BOARD_POWER_LIMIT so TBP is visible alongside core (TDP) power in the GUI and JSON snapshot.

Fix for issue - https://github.com/tenstorrent/tt-smi/issues/112