### PR TITLE
Add GDDR Telemetry tab and per-channel snapshot struct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The GUI has five tabs. Each row is one device (except the Processes tab, which l
 | Board Type | Product / board series identifier (for example `p150a`, `n300`, `tt-galaxy-bh`). An `R` suffix means the chip is a remote (non-PCIe host) chip on a multi-chip board. |
 | Board ID | Unique board serial / board ID string read from the device. |
 | Coords | Ethernet mesh coordinates for Wormhole multi-chip systems, shown as `(x, y, rack, shelf)`. Shown as `N/A` on Blackhole. |
-| DRAM Trained | Whether on-board DRAM/GDDR completed training successfully (`Yes` / `No`). |
+| DRAM Trained | Whether on-board DRAM/GDDR completed training successfully (`Yes` / `No`). On Blackhole, one harvested GDDR channel is still a pass (7 of 8 trained + BIST). |
 | DRAM Speed | Trained DRAM/GDDR data rate (for example `16G`). |
 | Link Speed | Current PCIe link generation negotiated with the host (for example Gen4 / Gen5). |
 | Link Width | Current PCIe link width in lanes (for example `8` or `16`). |
@@ -184,16 +184,17 @@ Live device metrics updated about every 100 ms. Where a limit applies, values ap
 
 #### GDDR Telemetry (3)
 
-Live per-channel GDDR metrics updated about every 100 ms. Blackhole reports temperatures, EDC error counts, training, and BIST for up to 8 channels. Wormhole reports training status for 6 channels; other fields show `N/A`. Harvested / disabled channels are marked `Enabled = N` with temperatures and errors as `N/A`.
+Live per-channel GDDR metrics updated about every 100 ms. Blackhole reports temperatures, EDC error counts, training, and BIST for up to 8 channels. Wormhole reports training status for 6 channels; other fields show `N/A`. Harvested channels are marked `Harvested = Y` with the remaining fields shown as `-`.
 
 | Field | Description |
 |-------|-------------|
 | `#` | Logical device index for this row. |
 | Ch | GDDR channel index on that device (`0`–`7` on Blackhole, `0`–`5` on Wormhole). |
+| Harvested | Whether this GDDR channel was harvested (`Y` / `N`). A harvested row shows `-` for the remaining fields. |
 | Enabled | Whether the channel is present and enabled (`Y` / `N`). |
 | Training | Channel training result (`Pass` / `Fail` / `N/A`). |
 | BIST | Built-in self-test result after training (`Pass` / `Fail` / `N/A`). Shown as `N/A` on firmware older than 19.7 and on Wormhole. |
-| Speed | Trained GDDR data rate (for example `16G`). Device-level; shown once per device. |
+| Speed | Trained GDDR data rate per channel (for example `16G`). Harvested, disabled, or failed-training channels show `N/A`. |
 | Top (°C) | Top DRAM die temperature in degrees Celsius. |
 | Bot (°C) | Bottom DRAM die temperature in degrees Celsius. |
 | Corr RD | Correctable EDC errors on read since reset (saturates at 255). Highlighted when non-zero. |

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ All GUI keyboard shortcuts can be found in the help menu that user can bring up 
 
 ### GUI Field Reference
 
-The GUI has four tabs. Each row is one device (except the Processes tab, which lists host processes using Tenstorrent devices). Several Telemetry values are shown as `current / limit` when a firmware limit is available.
+The GUI has five tabs. Each row is one device (except the Processes tab, which lists host processes using Tenstorrent devices, and the GDDR Telemetry tab, which lists one row per GDDR channel). Several Telemetry values are shown as `current / limit` when a firmware limit is available.
 
 #### Information (1)
 
@@ -182,7 +182,26 @@ Live device metrics updated about every 100 ms. Where a limit applies, values ap
 | Fan Speed (RPM) | Cooling fan speed in revolutions per minute. Shown as `N/A` when the board has no controllable fan or fan telemetry is unavailable. |
 | Heartbeat | Animated indicator that firmware is alive and updating. The spinner advances while the on-device firmware heartbeat counter is increasing. |
 
-#### FW Version (3)
+#### GDDR Telemetry (3)
+
+Live per-channel GDDR metrics updated about every 100 ms. Blackhole reports temperatures, EDC error counts, training, and BIST for up to 8 channels. Wormhole reports training status for 6 channels; other fields show `N/A`. Harvested / disabled channels are marked `Enabled = N` with temperatures and errors as `N/A`.
+
+| Field | Description |
+|-------|-------------|
+| `#` | Logical device index for this row. |
+| Ch | GDDR channel index on that device (`0`–`7` on Blackhole, `0`–`5` on Wormhole). |
+| Enabled | Whether the channel is present and enabled (`Y` / `N`). |
+| Training | Channel training result (`Pass` / `Fail` / `N/A`). |
+| BIST | Built-in self-test result after training (`Pass` / `Fail` / `N/A`). Shown as `N/A` on firmware older than 19.7 and on Wormhole. |
+| Speed | Trained GDDR data rate (for example `16G`). Device-level; shown once per device. |
+| Top (°C) | Top DRAM die temperature in degrees Celsius. |
+| Bot (°C) | Bottom DRAM die temperature in degrees Celsius. |
+| Corr RD | Correctable EDC errors on read since reset (saturates at 255). Highlighted when non-zero. |
+| Corr WR | Correctable EDC errors on write since reset (saturates at 255). Highlighted when non-zero. |
+| Uncorr RD | Uncorrectable EDC error flag on read (`0` / `1`). Highlighted when set. |
+| Uncorr WR | Uncorrectable EDC error flag on write (`0` / `1`). Highlighted when set. |
+
+#### FW Version (4)
 
 | Field | Description |
 |-------|-------------|
@@ -193,7 +212,7 @@ Live device metrics updated about every 100 ms. Where a limit applies, values ap
 | DM App Version | Device Management (DM) application firmware version — board management microcontroller application software. |
 | GDDR FW Version | GDDR memory controller firmware version (Blackhole). Shown as `N/A` on boards that do not report it. |
 
-#### Processes (4)
+#### Processes (5)
 
 Host processes currently holding open Tenstorrent device handles. Updated about every 100 ms.
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -115,6 +115,7 @@ class TestSnapshot:
         """Test if fields are present in gddr_telemetry."""
         channel_fields = (
             "channel",
+            "harvested",
             "enabled",
             "training",
             "bist",

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -48,6 +48,7 @@ class TestSnapshot:
             assert "smbus_telem" in device_info
             assert "board_info" in device_info
             assert "telemetry" in device_info
+            assert "gddr_telemetry" in device_info
             assert "firmwares" in device_info
             assert "limits" in device_info
 
@@ -109,6 +110,33 @@ class TestSnapshot:
             assert "asic_temperature" in telemetry
             assert "fan_speed" in telemetry
             assert "heartbeat" in telemetry
+
+    def test_gddr_telemetry_fields_present(self, snapshot):
+        """Test if fields are present in gddr_telemetry."""
+        channel_fields = (
+            "channel",
+            "enabled",
+            "training",
+            "bist",
+            "temp_top",
+            "temp_bottom",
+            "corr_rd",
+            "corr_wr",
+            "uncorr_rd",
+            "uncorr_wr",
+        )
+        device_infos = snapshot["device_info"]
+        for device_info in device_infos:
+            gddr = device_info["gddr_telemetry"]
+            assert "speed" in gddr
+            assert "max_temp" in gddr
+            assert "enabled_mask" in gddr
+            assert "channels" in gddr
+            assert isinstance(gddr["channels"], list)
+            assert len(gddr["channels"]) in (6, 8)
+            for ch in gddr["channels"]:
+                for field in channel_fields:
+                    assert field in ch
 
     def test_firmwares_fields_present(self, snapshot):
         """Test if fields are present in firmwares."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from tt_smi.utils import (
     hex_to_semver_gddr_fw,
     is_driver_version_at_least,
     p100_dram_training_passed,
+    bh_dram_training_passed,
     decode_gddr_pair_temps,
     decode_gddr_pair_corr_errs,
     decode_gddr_uncorr_errs,
@@ -225,10 +226,43 @@ class TestGddrTelemetryDecode:
             has_bist=True,
         )
         ch0 = gddr["channels"][0]
+        assert ch0["harvested"] is True
         assert ch0["enabled"] is False
         assert ch0["temp_top"] == "N/A"
         assert gddr["channels"][1]["enabled"] is True
         assert gddr["channels"][1]["temp_top"] == "30"
+
+    def test_build_gddr_telemetry_harvested_via_ddr_status(self):
+        """Harvested slot is 0b00 in DDR_STATUS even when ENABLED_GDDR is 0xff."""
+        smbus = {
+            "DDR_STATUS": hex(_p100_dram_status(harvested=2)),
+            "ENABLED_GDDR": "0xff",
+            "GDDR_0_1_TEMP": "0x1e1e2c2e",
+            "GDDR_2_3_TEMP": "0x2c2a2c2e",
+            "GDDR_4_5_TEMP": "0x0",
+            "GDDR_6_7_TEMP": "0x0",
+            "GDDR_0_1_CORR_ERRS": "0x0",
+            "GDDR_2_3_CORR_ERRS": "0x0",
+            "GDDR_4_5_CORR_ERRS": "0x0",
+            "GDDR_6_7_CORR_ERRS": "0x0",
+            "GDDR_UNCORR_ERRS": "0x0",
+            "MAX_GDDR_TEMP": "0x2e",
+        }
+        gddr = build_gddr_telemetry(
+            smbus,
+            dram_speed="16G",
+            is_blackhole=True,
+            is_wormhole=False,
+            has_bist=True,
+        )
+        ch2 = gddr["channels"][2]
+        assert ch2["harvested"] is True
+        assert ch2["enabled"] is False
+        assert ch2["training"] == "n/a"
+        assert ch2["bist"] == "n/a"
+        assert ch2["temp_top"] == "N/A"
+        assert gddr["channels"][0]["enabled"] is True
+        assert gddr["channels"][0]["training"] == "pass"
 
     def test_build_gddr_telemetry_wormhole(self):
         smbus = {"DDR_STATUS": "0x02222222"}
@@ -259,17 +293,17 @@ def _p100_dram_status(*, harvested: int = None, fail_training: int = None, fail_
     return status
 
 
-class TestP100DramTrainingPassed:
+class TestBhDramTrainingPassed:
     @pytest.mark.parametrize(
         "dram_status,expected",
         [
+            # All 8 channels trained + BIST
+            (0x55555555, True),
             # 7 active channels + GDDR 2 harvested (real P100 example)
             (0x55455545, True),
             # Harvested slot can be any of the 8 channels
             (_p100_dram_status(harvested=0), True),
             (_p100_dram_status(harvested=7), True),
-            # All 8 channels trained — valid for non-P100, not the P100 7+1 layout
-            (0x55555555, False),
             # Two harvested channels
             (0x54455545, False),
             (_p100_dram_status(harvested=0, fail_training=1), False),
@@ -283,5 +317,7 @@ class TestP100DramTrainingPassed:
             (0x55455540, False),
         ],
     )
-    def test_p100_dram_training_passed(self, dram_status, expected):
+    def test_bh_dram_training_passed(self, dram_status, expected):
+        assert bh_dram_training_passed(dram_status) is expected
+        # Back-compat alias used by older P100-only call sites.
         assert p100_dram_training_passed(dram_status) is expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,12 @@ from tt_smi.utils import (
     hex_to_semver_gddr_fw,
     is_driver_version_at_least,
     p100_dram_training_passed,
+    decode_gddr_pair_temps,
+    decode_gddr_pair_corr_errs,
+    decode_gddr_uncorr_errs,
+    decode_bh_gddr_channel_status,
+    decode_wh_gddr_channel_training,
+    build_gddr_telemetry,
 )
 
 class TestDriverVersion:
@@ -112,6 +118,131 @@ class TestHexToSemverGddrFw:
     )
     def test_hex_to_semver_gddr_fw(self, raw, expected):
         assert hex_to_semver_gddr_fw(raw) == expected
+
+
+class TestGddrTelemetryDecode:
+    """Packed BH GDDR telemetry tags (temps, EDC errors, DDR_STATUS)."""
+
+    def test_decode_gddr_pair_temps(self):
+        # hello.log device 0 GDDR_0_1_TEMP = 0x1e1e2c2e
+        (x_bottom, x_top), (y_bottom, y_top) = decode_gddr_pair_temps(0x1E1E2C2E)
+        assert (x_bottom, x_top) == (0x2E, 0x2C)
+        assert (y_bottom, y_top) == (0x1E, 0x1E)
+
+    def test_decode_gddr_pair_corr_errs(self):
+        packed = (7 << 24) | (6 << 16) | (5 << 8) | 4
+        (x_rd, x_wr), (y_rd, y_wr) = decode_gddr_pair_corr_errs(packed)
+        assert (x_rd, x_wr) == (4, 5)
+        assert (y_rd, y_wr) == (6, 7)
+
+    def test_decode_gddr_uncorr_errs(self):
+        # Channel 3 write + channel 0 read
+        packed = (1 << 0) | (1 << 7)
+        assert decode_gddr_uncorr_errs(packed, 0) == (1, 0)
+        assert decode_gddr_uncorr_errs(packed, 3) == (0, 1)
+        assert decode_gddr_uncorr_errs(packed, 1) == (0, 0)
+
+    def test_decode_bh_gddr_channel_status_all_pass(self):
+        training, bist = decode_bh_gddr_channel_status(0x55555555, 0, has_bist=True)
+        assert training == "pass"
+        assert bist == "pass"
+
+    def test_decode_bh_gddr_channel_status_fail(self):
+        # Channel 1 training error (bit 3) and BIST failed (bit 19)
+        status = (1 << 3) | (1 << 19)
+        training, bist = decode_bh_gddr_channel_status(status, 1, has_bist=True)
+        assert training == "fail"
+        assert bist == "fail"
+
+    def test_decode_bh_gddr_channel_status_no_bist(self):
+        training, bist = decode_bh_gddr_channel_status(0x5555, 0, has_bist=False)
+        assert training == "pass"
+        assert bist == "n/a"
+
+    def test_decode_wh_gddr_channel_training(self):
+        # 6 channels all pass: 0x222222
+        assert decode_wh_gddr_channel_training(0x222222, 0) == "pass"
+        assert decode_wh_gddr_channel_training(0x000001, 0) == "fail"
+        assert decode_wh_gddr_channel_training(0x0, 0) == "n/a"
+
+    def test_build_gddr_telemetry_blackhole(self):
+        smbus = {
+            "DDR_STATUS": "0x55555555",
+            "DDR_SPEED": "0x3e80",
+            "ENABLED_GDDR": "0xff",
+            "GDDR_0_1_TEMP": "0x1e1e2c2e",
+            "GDDR_2_3_TEMP": "0x2c2a2c2e",
+            "GDDR_4_5_TEMP": "0x2a2a2a2a",
+            "GDDR_6_7_TEMP": "0x2a2a1e1c",
+            "GDDR_0_1_CORR_ERRS": "0x0",
+            "GDDR_2_3_CORR_ERRS": "0x0",
+            "GDDR_4_5_CORR_ERRS": "0x0",
+            "GDDR_6_7_CORR_ERRS": "0x0",
+            "GDDR_UNCORR_ERRS": "0x0",
+            "MAX_GDDR_TEMP": "0x2e",
+        }
+        gddr = build_gddr_telemetry(
+            smbus,
+            dram_speed="16G",
+            is_blackhole=True,
+            is_wormhole=False,
+            has_bist=True,
+        )
+        assert gddr["speed"] == "16G"
+        assert gddr["max_temp"] == "46"
+        assert gddr["enabled_mask"] == "0xff"
+        assert len(gddr["channels"]) == 8
+        ch0 = gddr["channels"][0]
+        assert ch0["channel"] == 0
+        assert ch0["enabled"] is True
+        assert ch0["training"] == "pass"
+        assert ch0["bist"] == "pass"
+        assert ch0["temp_bottom"] == "46"
+        assert ch0["temp_top"] == "44"
+        assert ch0["corr_rd"] == "0"
+        assert ch0["uncorr_wr"] == "0"
+
+    def test_build_gddr_telemetry_harvested_channel(self):
+        smbus = {
+            "DDR_STATUS": "0x55555555",
+            "ENABLED_GDDR": "0xfe",  # channel 0 harvested
+            "GDDR_0_1_TEMP": "0x1e1e2c2e",
+            "GDDR_2_3_TEMP": "0x0",
+            "GDDR_4_5_TEMP": "0x0",
+            "GDDR_6_7_TEMP": "0x0",
+            "GDDR_0_1_CORR_ERRS": "0x0",
+            "GDDR_2_3_CORR_ERRS": "0x0",
+            "GDDR_4_5_CORR_ERRS": "0x0",
+            "GDDR_6_7_CORR_ERRS": "0x0",
+            "GDDR_UNCORR_ERRS": "0x0",
+            "MAX_GDDR_TEMP": "0x2e",
+        }
+        gddr = build_gddr_telemetry(
+            smbus,
+            dram_speed="16G",
+            is_blackhole=True,
+            is_wormhole=False,
+            has_bist=True,
+        )
+        ch0 = gddr["channels"][0]
+        assert ch0["enabled"] is False
+        assert ch0["temp_top"] == "N/A"
+        assert gddr["channels"][1]["enabled"] is True
+        assert gddr["channels"][1]["temp_top"] == "30"
+
+    def test_build_gddr_telemetry_wormhole(self):
+        smbus = {"DDR_STATUS": "0x02222222"}
+        gddr = build_gddr_telemetry(
+            smbus,
+            dram_speed="16G",
+            is_blackhole=False,
+            is_wormhole=True,
+            has_bist=False,
+        )
+        assert gddr["max_temp"] == "N/A"
+        assert len(gddr["channels"]) == 6
+        assert all(ch["training"] == "pass" for ch in gddr["channels"])
+        assert all(ch["temp_top"] == "N/A" for ch in gddr["channels"])
 
 
 def _p100_dram_status(*, harvested: int = None, fail_training: int = None, fail_bist: int = None) -> int:

--- a/tt_smi/backend.py
+++ b/tt_smi/backend.py
@@ -35,7 +35,7 @@ from tt_smi.utils import (
     dict_from_public_attrs,
     get_host_software_versions,
     get_fw_bundle_version,
-    p100_dram_training_passed,
+    bh_dram_training_passed,
     build_gddr_telemetry,
     BH_GDDR_BIST_FW_VERSION,
 )
@@ -597,14 +597,8 @@ class TTSMIBackend:
                 # ...
                 # [30] - BIST complete GDDR 7
                 # [31] - BIST failed GDDR 7
-                if dram_status == 0x55555555:
-                    return True
-                # check if its p100 and if so, check if the training passed
-                match get_board_type(self.get_board_id(board_num)):
-                    case "p100a":
-                        return p100_dram_training_passed(dram_status)
-                    case _:
-                        return False
+                # All 8 trained, or 7 trained + 1 harvested (PT-505, any BH ASIC).
+                return bh_dram_training_passed(dram_status)
             else:
                 # Pre-19.7.0.3 DDR Status in BH is a 16-bit field with the following layout:
                 #  [0] - Training complete GDDR 0

--- a/tt_smi/backend.py
+++ b/tt_smi/backend.py
@@ -36,6 +36,8 @@ from tt_smi.utils import (
     get_host_software_versions,
     get_fw_bundle_version,
     p100_dram_training_passed,
+    build_gddr_telemetry,
+    BH_GDDR_BIST_FW_VERSION,
 )
 from tt_umd import (
     TTDevice,
@@ -77,6 +79,7 @@ class TTSMIBackend:
                     smbus_telem=log.SmbusTelem(),
                     board_info=log.BoardInfo(),
                     telemetry=log.Telemetry(),
+                    gddr_telemetry=log.GddrTelemetry(),
                     firmwares=log.Firmwares(),
                     limits=log.Limits(),
                 )
@@ -87,6 +90,7 @@ class TTSMIBackend:
         self.firmware_infos = []
         self.device_infos = []
         self.device_telemetrys = []
+        self.device_gddr_telemetrys = []
         self.chip_limits = []
         self.pci_properties = []
         self.device_processes = []
@@ -104,6 +108,7 @@ class TTSMIBackend:
                 self.pci_properties.append(self.get_pci_properties(i))
                 self.device_infos.append(self.get_device_info(i))
                 self.device_telemetrys.append(self.get_chip_telemetry(i))
+                self.device_gddr_telemetrys.append(self.get_gddr_telemetry(i))
                 self.chip_limits.append(self.get_chip_limits(i))
     
     def is_blackhole(self, device_idx) -> bool:
@@ -181,6 +186,7 @@ class TTSMIBackend:
                 board_type = board_type + suffix
                 self.log.device_info[i].board_info["board_type"] = board_type
             self.log.device_info[i].telemetry = self.device_telemetrys[i]
+            self.log.device_info[i].gddr_telemetry = self.device_gddr_telemetrys[i]
             self.log.device_info[i].firmwares = self.firmware_infos[i]
             self.log.device_info[i].limits = self.chip_limits[i]
 
@@ -381,6 +387,7 @@ class TTSMIBackend:
         for i in self.devices:
             self.smbus_telem_info[i] = self.get_smbus_board_info(i)
             self.device_telemetrys[i] = self.get_chip_telemetry(i)
+            self.device_gddr_telemetrys[i] = self.get_gddr_telemetry(i)
 
     def get_device_processes(self):
         """Scan /proc/driver/tenstorrent/N/pids for processes using devices."""
@@ -760,6 +767,26 @@ class TTSMIBackend:
                 CMD_LINE_COLOR.ENDC,
             )
             return {}
+
+    def get_gddr_telemetry(self, board_num) -> Dict:
+        """Return decoded per-channel GDDR telemetry for a board."""
+        dram_speed = self.get_dram_speed(board_num)
+        if dram_speed is None:
+            dram_speed = "N/A"
+
+        has_bist = False
+        if self.is_blackhole(board_num):
+            fw_bundle = get_fw_bundle_version(self.smbus_telem_info[board_num])
+            if fw_bundle is not None:
+                has_bist = int(fw_bundle, 16) >= BH_GDDR_BIST_FW_VERSION
+
+        return build_gddr_telemetry(
+            self.smbus_telem_info[board_num],
+            dram_speed=dram_speed,
+            is_blackhole=self.is_blackhole(board_num),
+            is_wormhole=self.is_wormhole(board_num),
+            has_bist=has_bist,
+        )
 
     def get_chip_limits(self, board_num: int) -> Dict[str, str]:
         if self.is_blackhole(board_num):

--- a/tt_smi/constants.py
+++ b/tt_smi/constants.py
@@ -219,6 +219,7 @@ TELEMETRY_TABLE_HEADER = [
 GDDR_TELEMETRY_TABLE_HEADER = [
     "#",
     "Ch",
+    "Harvested",
     "Enabled",
     "Training",
     "BIST",

--- a/tt_smi/constants.py
+++ b/tt_smi/constants.py
@@ -216,6 +216,21 @@ TELEMETRY_TABLE_HEADER = [
     "Heartbeat",
 ]
 
+GDDR_TELEMETRY_TABLE_HEADER = [
+    "#",
+    "Ch",
+    "Enabled",
+    "Training",
+    "BIST",
+    "Speed",
+    "Top (°C)",
+    "Bot (°C)",
+    "Corr RD",
+    "Corr WR",
+    "Uncorr RD",
+    "Uncorr WR",
+]
+
 FIRMWARES_TABLE_HEADER = [
     "#",
     "FW Bundle Version",
@@ -256,7 +271,8 @@ Use cursor or keyboard keys to navigate the app. The following table details the
 |             Help             |   h   |                   Opens up this help menu                   |
 |   Go to device(s) info tab  |        1        |          Switch to tab with device info         |
 |   Go to device(s) telemetry tab     |        2        |          Switch to tab with telemetry info that is updated every 100ms           |
-|   Go to device(s) firmware tab     |        3        |          Switch to tab with all the fw versions on the board(s)          |
-|   Go to process(es) tab    |        4        |          Switch to tab with process info that is updated every 100ms           |
+|   Go to GDDR telemetry tab    |        3        |          Switch to tab with per-channel GDDR telemetry that is updated every 100ms           |
+|   Go to device(s) firmware tab     |        4        |          Switch to tab with all the fw versions on the board(s)          |
+|   Go to process(es) tab    |        5        |          Switch to tab with process info that is updated every 100ms           |
 
 """

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -156,8 +156,9 @@ class TTSMI(App):
         ("c, C", "toggle_compact", "Toggle sidebar"),
         ("1", "tab_one", "Device info tab"),
         ("2", "tab_two", "Telemetry tab"),
-        ("3", "tab_three", "Firmware tab"),
-        ("4", "tab_four", "Processes tab"),
+        ("3", "tab_three", "GDDR telemetry tab"),
+        ("4", "tab_four", "Firmware tab"),
+        ("5", "tab_five", "Processes tab"),
     ]
 
     try:
@@ -225,7 +226,12 @@ class TTSMI(App):
                         title="Latest Releases",
                     )
             with TabbedContent(
-                "Information (1)", "Telemetry (2)", "FW Version (3)", "Processes (4)", id="tab_container"
+                "Information (1)",
+                "Telemetry (2)",
+                "GDDR Telemetry (3)",
+                "FW Version (4)",
+                "Processes (5)",
+                id="tab_container",
             ):
                 yield TTDataTable(
                     title="Device Information",
@@ -237,6 +243,12 @@ class TTSMI(App):
                     title="Device Telemetry",
                     id="tt_smi_telem",
                     header=constants.TELEMETRY_TABLE_HEADER,
+                    header_height=2,
+                )
+                yield TTDataTable(
+                    title="GDDR Telemetry",
+                    id="tt_smi_gddr_telem",
+                    header=constants.GDDR_TELEMETRY_TABLE_HEADER,
                     header_height=2,
                 )
                 yield TTDataTable(
@@ -272,6 +284,10 @@ class TTSMI(App):
         self.backend.update_processes()
         proc_table.dt.add_rows(self.format_process_rows())
 
+        gddr_table = self.get_widget_by_id(id="tt_smi_gddr_telem")
+        gddr_table.dt.cursor_type = "none"
+        gddr_table.dt.add_rows(self.format_gddr_telemetry_rows())
+
         left_sidebar = self.query_one("#left_col")
         left_sidebar.display = self.show_sidebar
 
@@ -302,14 +318,19 @@ class TTSMI(App):
         self.call_from_thread(box.finalize)
 
     def update_telem_table(self) -> None:
-        """Update telemetry table"""
+        """Update telemetry tables"""
+        self.backend.update_telem()
         try:
             telem_table = self.get_widget_by_id(id="tt_smi_telem")
-            self.backend.update_telem()
             rows = self.format_telemetry_rows()
             telem_table.update_data(rows)
         # When we bring up the help menu, the telem table is no longer visible,
         # but the thread keeps running, so we need to ignore that exception.
+        except NoMatches:
+            pass
+        try:
+            gddr_table = self.get_widget_by_id(id="tt_smi_gddr_telem")
+            gddr_table.update_data(self.format_gddr_telemetry_rows())
         except NoMatches:
             pass
 
@@ -497,6 +518,100 @@ class TTSMI(App):
                         Text(f"{val}", style=self.text_theme["text_green"], justify="center")
                     )
             all_rows.append(device_row)
+        return all_rows
+
+    def _gddr_status_text(self, val: str) -> Text:
+        """Format a pass/fail/n/a GDDR status cell."""
+        display = val.title() if val != "n/a" else "N/A"
+        if val == "pass":
+            style = self.text_theme["text_green"]
+        elif val == "fail":
+            style = self.text_theme["attention"]
+        else:
+            style = self.text_theme["gray"]
+        return Text(display, style=style, justify="center")
+
+    def _gddr_value_text(self, val: str, alert: bool = False) -> Text:
+        """Format a numeric GDDR cell; gray N/A, red when alert is set."""
+        if val in (None, "N/A", "n/a"):
+            return Text("N/A", style=self.text_theme["gray"], justify="center")
+        style = self.text_theme["attention"] if alert else self.text_theme["text_green"]
+        return Text(str(val), style=style, justify="center")
+
+    def _gddr_separator_row(self) -> List[Text]:
+        """Gray dashed row used to separate device channel groups."""
+        ncols = len(constants.GDDR_TELEMETRY_TABLE_HEADER)
+        return [
+            Text("────", style=self.text_theme["gray"], justify="center")
+            for _ in range(ncols)
+        ]
+
+    def format_gddr_telemetry_rows(self) -> List[List[Text]]:
+        """Format GDDR telemetry rows (one row per channel)."""
+        all_rows = []
+        first_device = True
+        for board_num in self.backend.devices:
+            gddr = self.backend.device_gddr_telemetrys[board_num]
+            speed = gddr.get("speed") or "N/A"
+            channels = gddr.get("channels", [])
+            if not channels:
+                continue
+            if not first_device:
+                all_rows.append(self._gddr_separator_row())
+            first_device = False
+            for ch_idx, ch in enumerate(channels):
+                enabled = bool(ch.get("enabled"))
+                uncorr_rd = ch.get("uncorr_rd", "N/A")
+                uncorr_wr = ch.get("uncorr_wr", "N/A")
+                corr_rd = ch.get("corr_rd", "N/A")
+                corr_wr = ch.get("corr_wr", "N/A")
+                # DataTable has no rowspan; show device-level fields once per group.
+                device_cell = (
+                    Text(f"{board_num}", style=self.text_theme["yellow_bold"], justify="center")
+                    if ch_idx == 0
+                    else Text("", justify="center")
+                )
+                speed_cell = (
+                    self._gddr_value_text(speed)
+                    if ch_idx == 0
+                    else Text("", justify="center")
+                )
+                row = [
+                    device_cell,
+                    Text(f"{ch.get('channel', 'N/A')}", style=self.text_theme["yellow_bold"], justify="center"),
+                    Text(
+                        "Y" if enabled else "N",
+                        style=self.text_theme["text_green"] if enabled else self.text_theme["gray"],
+                        justify="center",
+                    ),
+                    self._gddr_status_text(ch.get("training", "n/a")),
+                    self._gddr_status_text(ch.get("bist", "n/a")),
+                    speed_cell,
+                    self._gddr_value_text(ch.get("temp_top", "N/A")),
+                    self._gddr_value_text(ch.get("temp_bottom", "N/A")),
+                    self._gddr_value_text(
+                        corr_rd,
+                        alert=corr_rd not in (None, "N/A", "n/a", "0") and enabled,
+                    ),
+                    self._gddr_value_text(
+                        corr_wr,
+                        alert=corr_wr not in (None, "N/A", "n/a", "0") and enabled,
+                    ),
+                    self._gddr_value_text(
+                        uncorr_rd,
+                        alert=uncorr_rd not in (None, "N/A", "n/a", "0") and enabled,
+                    ),
+                    self._gddr_value_text(
+                        uncorr_wr,
+                        alert=uncorr_wr not in (None, "N/A", "n/a", "0") and enabled,
+                    ),
+                ]
+                all_rows.append(row)
+        if not all_rows:
+            ncols = len(constants.GDDR_TELEMETRY_TABLE_HEADER)
+            empty = [Text("", justify="center") for _ in range(ncols)]
+            empty[0] = Text("No GDDR telemetry", style=self.text_theme["gray"], justify="center")
+            all_rows.append(empty)
         return all_rows
 
     def get_heartbeat_spinner(self, input_secs: Union[int, str]) -> str:
@@ -733,12 +848,16 @@ class TTSMI(App):
         self.query_one(TabbedContent).active = "tab-2"
 
     def action_tab_three(self) -> None:
-        """Switch to read-only tab"""
+        """Switch to GDDR telemetry tab"""
         self.query_one(TabbedContent).active = "tab-3"
 
     def action_tab_four(self) -> None:
-        """Switch to processes tab"""
+        """Switch to firmware tab"""
         self.query_one(TabbedContent).active = "tab-4"
+
+    def action_tab_five(self) -> None:
+        """Switch to processes tab"""
+        self.query_one(TabbedContent).active = "tab-5"
 
     def action_help(self) -> None:
         """Pop up the help menu"""
@@ -785,9 +904,9 @@ class TTSMI(App):
         """This function runs every time a tab is activated"""
         tab_id = self.query_one(TabbedContent).active
 
-        if tab_id == "tab-2":
+        if tab_id == "tab-2" or tab_id == "tab-3":
             self.dispatch_telem_thread()
-        elif tab_id == "tab-4":
+        elif tab_id == "tab-5":
             self.dispatch_process_thread()
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -526,7 +526,7 @@ class TTSMI(App):
         if val == "pass":
             style = self.text_theme["text_green"]
         elif val == "fail":
-            style = self.text_theme["attention"]
+            style = self.text_theme["red_bold"]
         else:
             style = self.text_theme["gray"]
         return Text(display, style=style, justify="center")
@@ -537,6 +537,10 @@ class TTSMI(App):
             return Text("N/A", style=self.text_theme["gray"], justify="center")
         style = self.text_theme["attention"] if alert else self.text_theme["text_green"]
         return Text(str(val), style=style, justify="center")
+
+    def _gddr_harvested_dash(self) -> Text:
+        """Placeholder for fields that do not apply on a harvested channel."""
+        return Text("-", style=self.text_theme["attention"], justify="center")
 
     def _gddr_separator_row(self) -> List[Text]:
         """Gray dashed row used to separate device channel groups."""
@@ -561,24 +565,43 @@ class TTSMI(App):
             first_device = False
             for ch_idx, ch in enumerate(channels):
                 enabled = bool(ch.get("enabled"))
+                harvested = bool(ch.get("harvested"))
                 uncorr_rd = ch.get("uncorr_rd", "N/A")
                 uncorr_wr = ch.get("uncorr_wr", "N/A")
                 corr_rd = ch.get("corr_rd", "N/A")
                 corr_wr = ch.get("corr_wr", "N/A")
-                # DataTable has no rowspan; show device-level fields once per group.
+                # DataTable has no rowspan; show the device index once per group.
                 device_cell = (
                     Text(f"{board_num}", style=self.text_theme["yellow_bold"], justify="center")
                     if ch_idx == 0
                     else Text("", justify="center")
                 )
-                speed_cell = (
-                    self._gddr_value_text(speed)
-                    if ch_idx == 0
-                    else Text("", justify="center")
+                failed = ch.get("training") == "fail" or ch.get("bist") == "fail"
+                channel_cell = Text(
+                    f"{ch.get('channel', 'N/A')}",
+                    style=self.text_theme["red_bold"] if failed else self.text_theme["yellow_bold"],
+                    justify="center",
                 )
+                harvested_cell = Text(
+                    "Y" if harvested else "N",
+                    style=self.text_theme["attention"] if harvested else self.text_theme["gray"],
+                    justify="center",
+                )
+                if harvested:
+                    row = [
+                        device_cell,
+                        channel_cell,
+                        harvested_cell,
+                    ] + [
+                        self._gddr_harvested_dash()
+                        for _ in range(len(constants.GDDR_TELEMETRY_TABLE_HEADER) - 3)
+                    ]
+                    all_rows.append(row)
+                    continue
                 row = [
                     device_cell,
-                    Text(f"{ch.get('channel', 'N/A')}", style=self.text_theme["yellow_bold"], justify="center"),
+                    channel_cell,
+                    harvested_cell,
                     Text(
                         "Y" if enabled else "N",
                         style=self.text_theme["text_green"] if enabled else self.text_theme["gray"],
@@ -586,7 +609,11 @@ class TTSMI(App):
                     ),
                     self._gddr_status_text(ch.get("training", "n/a")),
                     self._gddr_status_text(ch.get("bist", "n/a")),
-                    speed_cell,
+                    self._gddr_value_text(
+                        speed
+                        if enabled and ch.get("training") == "pass"
+                        else "N/A"
+                    ),
                     self._gddr_value_text(ch.get("temp_top", "N/A")),
                     self._gddr_value_text(ch.get("temp_bottom", "N/A")),
                     self._gddr_value_text(

--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -234,6 +234,28 @@ class Telemetry(ElasticModel):
 
 
 @optional
+class GddrChannelTelemetry(ElasticModel):
+    channel: int
+    enabled: bool
+    training: str
+    bist: str
+    temp_top: str
+    temp_bottom: str
+    corr_rd: str
+    corr_wr: str
+    uncorr_rd: str
+    uncorr_wr: str
+
+
+@optional
+class GddrTelemetry(ElasticModel):
+    speed: str
+    max_temp: str
+    enabled_mask: str
+    channels: List[GddrChannelTelemetry]
+
+
+@optional
 class Firmwares(ElasticModel):
     cm_fw: str
     cm_fw_date: str
@@ -262,6 +284,7 @@ class TTSMIDeviceLog(ElasticModel):
     smbus_telem: SmbusTelem
     board_info: BoardInfo
     telemetry: Telemetry
+    gddr_telemetry: GddrTelemetry
     firmwares: Firmwares
     limits: Limits
 

--- a/tt_smi/log.py
+++ b/tt_smi/log.py
@@ -236,6 +236,7 @@ class Telemetry(ElasticModel):
 @optional
 class GddrChannelTelemetry(ElasticModel):
     channel: int
+    harvested: bool
     enabled: bool
     training: str
     bist: str

--- a/tt_smi/tt_smi_style.css
+++ b/tt_smi/tt_smi_style.css
@@ -121,7 +121,7 @@ LatestReleasesBox Static {
 #help_menu_box {
   padding: 1 2;
   width: 110;
-  height: 33;
+  height: 36;
   border: solid $green;
   background: $surface;
   color: white;

--- a/tt_smi/utils.py
+++ b/tt_smi/utils.py
@@ -286,9 +286,10 @@ def decode_wh_gddr_channel_training(dram_status: int, channel: int) -> str:
     return "n/a"
 
 
-def _gddr_channel_na(channel: int, enabled: bool = False) -> Dict[str, Any]:
+def _gddr_channel_na(channel: int, enabled: bool = False, harvested: bool = False) -> Dict[str, Any]:
     return {
         "channel": channel,
+        "harvested": harvested,
         "enabled": enabled,
         "training": "n/a",
         "bist": "n/a",
@@ -346,7 +347,13 @@ def build_gddr_telemetry(
 
         for channel in range(BH_GDDR_CHANNELS):
             enabled = bool(enabled_mask & (1 << channel))
-            ch = _gddr_channel_na(channel, enabled=enabled)
+            harvested = (not enabled) or (
+                dram_status is not None
+                and is_bh_gddr_channel_harvested(dram_status, channel, has_bist)
+            )
+            if harvested:
+                enabled = False
+            ch = _gddr_channel_na(channel, enabled=enabled, harvested=harvested)
             if dram_status is not None:
                 training, bist = decode_bh_gddr_channel_status(
                     dram_status, channel, has_bist
@@ -387,52 +394,50 @@ def build_gddr_telemetry(
     return gddr
 
 
-def p100_dram_training_passed(dram_status: int) -> bool:
-    """
-    Check if DRAM training passed for P100.
+def is_bh_gddr_channel_harvested(
+    dram_status: int, channel: int, has_bist: bool
+) -> bool:
+    """True when a BH GDDR channel never ran training/BIST (0b00 / 0b00)."""
+    if not has_bist:
+        return False
+    training, bist = decode_bh_gddr_channel_status(
+        dram_status, channel, has_bist=True
+    )
+    return training == "n/a" and bist == "n/a"
 
-    P100 may ship with one harvested GDDR channel (any of the 8). Pass when
-    exactly 7 channels report training+BIST success (0b01 in each 2-bit field),
-    and one channel reports all status bits clear (0b00 — absent/harvested slot).
+
+def bh_dram_training_passed(dram_status: int) -> bool:
+    """
+    Check if DRAM training passed for Blackhole.
+
+    Firmware may harvest up to one GDDR channel on any BH ASIC (PT-505).
+    Pass when all 8 channels report training+BIST success (0b01), or when
+    exactly 7 channels pass and one slot is all zeros (0b00 — harvested).
+    A training/BIST error on any channel, more than one harvested slot, or a
+    partial/incomplete state is a fail.
     """
     passing_channels = 0
     harvested_channels = 0
 
-    for channel in range(8):
-        # Per-channel DDR_STATUS layout (FW 19.7.3.0+):
-        #   bits [2i+1:2i]     - [training error | training complete]
-        #   bits [17+2i:16+2i] - [BIST failed    | BIST complete]
-        #
-        # 0b01 = success, 0b10 = failure, 0b00 = not run (harvested on P100)
-        training_complete = bool(dram_status & (1 << (2 * channel)))
-        training_error = bool(dram_status & (1 << (2 * channel + 1)))
-        bist_complete = bool(dram_status & (1 << (16 + 2 * channel)))
-        bist_failed = bool(dram_status & (1 << (17 + 2 * channel)))
-
-        if (
-            training_complete
-            and not training_error
-            and bist_complete
-            and not bist_failed
-        ):
-            # Active channel: trained and passed BIST (0b01 / 0b01).
+    for channel in range(BH_GDDR_CHANNELS):
+        training, bist = decode_bh_gddr_channel_status(
+            dram_status, channel, has_bist=True
+        )
+        if training == "pass" and bist == "pass":
             passing_channels += 1
-        elif (
-            not training_complete
-            and not training_error
-            and not bist_complete
-            and not bist_failed
-        ):
-            # Harvested channel: firmware never ran training/BIST (0b00 / 0b00).
+        elif training == "n/a" and bist == "n/a":
             harvested_channels += 1
             if harvested_channels > 1:
                 return False
         else:
-            # Real failure: error/fail bit set, or partial/incomplete state.
             return False
 
-    # P100 expects 7 active GDDR channels and 1 harvested slot.
-    return passing_channels == 7 and harvested_channels == 1
+    return passing_channels + harvested_channels == BH_GDDR_CHANNELS and harvested_channels <= 1
+
+
+def p100_dram_training_passed(dram_status: int) -> bool:
+    """Alias for bh_dram_training_passed; P100 uses the same harvest-tolerant check."""
+    return bh_dram_training_passed(dram_status)
 
 
 def get_board_type(board_id: str) -> str:

--- a/tt_smi/utils.py
+++ b/tt_smi/utils.py
@@ -12,7 +12,7 @@ import fcntl
 import struct
 from enum import IntEnum
 from importlib.metadata import version
-from typing import Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from tt_tools_common.ui_common.themes import CMD_LINE_COLOR
 
@@ -174,6 +174,217 @@ def hex_to_semver_gddr_fw(raw: int) -> str:
     major = (raw >> 16) & 0xFFFF
     minor = raw & 0xFFFF
     return f"{major}.{minor}"
+
+
+BH_GDDR_CHANNELS = 8
+WH_GDDR_CHANNELS = 6
+
+# Packed GDDR_x_y_TEMP / GDDR_x_y_CORR_ERRS tags, in channel-pair order.
+BH_GDDR_TEMP_TAGS = (
+    "GDDR_0_1_TEMP",
+    "GDDR_2_3_TEMP",
+    "GDDR_4_5_TEMP",
+    "GDDR_6_7_TEMP",
+)
+BH_GDDR_CORR_ERR_TAGS = (
+    "GDDR_0_1_CORR_ERRS",
+    "GDDR_2_3_CORR_ERRS",
+    "GDDR_4_5_CORR_ERRS",
+    "GDDR_6_7_CORR_ERRS",
+)
+
+# FW 19.7.0.0+ includes per-channel BIST bits in DDR_STATUS [31:16].
+BH_GDDR_BIST_FW_VERSION = 0x13070000
+
+
+def parse_telem_hex(smbus_telem: dict, key: str) -> Optional[int]:
+    """Parse a hex telemetry tag from smbus_telem, or None if missing."""
+    val = smbus_telem.get(key)
+    if val is None:
+        return None
+    return int(val, 16)
+
+
+def decode_gddr_pair_temps(packed: int) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    """Decode a GDDR_x_y_TEMP word into ((x_bottom, x_top), (y_bottom, y_top)).
+
+    Firmware packs each pair as:
+      [7:0]   x bottom die °C
+      [15:8]  x top die °C
+      [23:16] y bottom die °C
+      [31:24] y top die °C
+    """
+    x_bottom = packed & 0xFF
+    x_top = (packed >> 8) & 0xFF
+    y_bottom = (packed >> 16) & 0xFF
+    y_top = (packed >> 24) & 0xFF
+    return (x_bottom, x_top), (y_bottom, y_top)
+
+
+def decode_gddr_pair_corr_errs(packed: int) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    """Decode a GDDR_x_y_CORR_ERRS word into ((x_rd, x_wr), (y_rd, y_wr)).
+
+    Firmware packs each pair as:
+      [7:0]   x corrected read EDC (saturates at 255)
+      [15:8]  x corrected write EDC
+      [23:16] y corrected read EDC
+      [31:24] y corrected write EDC
+    """
+    x_rd = packed & 0xFF
+    x_wr = (packed >> 8) & 0xFF
+    y_rd = (packed >> 16) & 0xFF
+    y_wr = (packed >> 24) & 0xFF
+    return (x_rd, x_wr), (y_rd, y_wr)
+
+
+def decode_gddr_uncorr_errs(packed: int, channel: int) -> Tuple[int, int]:
+    """Return (uncorr_rd, uncorr_wr) flags for one channel from GDDR_UNCORR_ERRS."""
+    rd = (packed >> (channel * 2)) & 1
+    wr = (packed >> (channel * 2 + 1)) & 1
+    return rd, wr
+
+
+def decode_bh_gddr_channel_status(
+    dram_status: int, channel: int, has_bist: bool
+) -> Tuple[str, str]:
+    """Decode BH DDR_STATUS training/BIST for one GDDR channel.
+
+    Per channel (FW 19.7+):
+      bits [2i+1:2i]     training (01 complete, 10 error, 00 not run)
+      bits [17+2i:16+2i] BIST     (01 complete, 10 failed, 00 not run)
+    """
+    training_complete = bool(dram_status & (1 << (2 * channel)))
+    training_error = bool(dram_status & (1 << (2 * channel + 1)))
+    if training_error:
+        training = "fail"
+    elif training_complete:
+        training = "pass"
+    else:
+        training = "n/a"
+
+    if not has_bist:
+        return training, "n/a"
+
+    bist_complete = bool(dram_status & (1 << (16 + 2 * channel)))
+    bist_failed = bool(dram_status & (1 << (17 + 2 * channel)))
+    if bist_failed:
+        bist = "fail"
+    elif bist_complete:
+        bist = "pass"
+    else:
+        bist = "n/a"
+    return training, bist
+
+
+def decode_wh_gddr_channel_training(dram_status: int, channel: int) -> str:
+    """Decode Wormhole DDR_STATUS nibble for one DRAM channel (0x2 pass, 0x1 fail)."""
+    nibble = (dram_status >> (channel * 4)) & 0xF
+    if nibble == 0x2:
+        return "pass"
+    if nibble == 0x1:
+        return "fail"
+    return "n/a"
+
+
+def _gddr_channel_na(channel: int, enabled: bool = False) -> Dict[str, Any]:
+    return {
+        "channel": channel,
+        "enabled": enabled,
+        "training": "n/a",
+        "bist": "n/a",
+        "temp_top": "N/A",
+        "temp_bottom": "N/A",
+        "corr_rd": "N/A",
+        "corr_wr": "N/A",
+        "uncorr_rd": "N/A",
+        "uncorr_wr": "N/A",
+    }
+
+
+def build_gddr_telemetry(
+    smbus_telem: dict,
+    dram_speed: str,
+    is_blackhole: bool,
+    is_wormhole: bool,
+    has_bist: bool,
+) -> Dict[str, Any]:
+    """Build the decoded GDDR telemetry struct used by the GUI and snapshot."""
+    gddr: Dict[str, Any] = {
+        "speed": dram_speed if dram_speed else "N/A",
+        "max_temp": "N/A",
+        "enabled_mask": "N/A",
+        "channels": [],
+    }
+
+    if is_blackhole:
+        enabled_mask = parse_telem_hex(smbus_telem, "ENABLED_GDDR")
+        if enabled_mask is not None:
+            gddr["enabled_mask"] = hex(enabled_mask)
+        else:
+            enabled_mask = (1 << BH_GDDR_CHANNELS) - 1
+
+        max_temp = parse_telem_hex(smbus_telem, "MAX_GDDR_TEMP")
+        if max_temp is not None:
+            gddr["max_temp"] = str(max_temp)
+
+        dram_status = parse_telem_hex(smbus_telem, "DDR_STATUS")
+        uncorr_packed = parse_telem_hex(smbus_telem, "GDDR_UNCORR_ERRS")
+
+        pair_temps: List[Optional[Tuple[Tuple[int, int], Tuple[int, int]]]] = []
+        pair_corrs: List[Optional[Tuple[Tuple[int, int], Tuple[int, int]]]] = []
+        for temp_tag, corr_tag in zip(BH_GDDR_TEMP_TAGS, BH_GDDR_CORR_ERR_TAGS):
+            temp_packed = parse_telem_hex(smbus_telem, temp_tag)
+            corr_packed = parse_telem_hex(smbus_telem, corr_tag)
+            pair_temps.append(
+                decode_gddr_pair_temps(temp_packed) if temp_packed is not None else None
+            )
+            pair_corrs.append(
+                decode_gddr_pair_corr_errs(corr_packed)
+                if corr_packed is not None
+                else None
+            )
+
+        for channel in range(BH_GDDR_CHANNELS):
+            enabled = bool(enabled_mask & (1 << channel))
+            ch = _gddr_channel_na(channel, enabled=enabled)
+            if dram_status is not None:
+                training, bist = decode_bh_gddr_channel_status(
+                    dram_status, channel, has_bist
+                )
+                ch["training"] = training
+                ch["bist"] = bist
+            if enabled:
+                pair_idx = channel // 2
+                lane = channel % 2
+                if pair_temps[pair_idx] is not None:
+                    bottom, top = pair_temps[pair_idx][lane]
+                    ch["temp_bottom"] = str(bottom)
+                    ch["temp_top"] = str(top)
+                if pair_corrs[pair_idx] is not None:
+                    corr_rd, corr_wr = pair_corrs[pair_idx][lane]
+                    ch["corr_rd"] = str(corr_rd)
+                    ch["corr_wr"] = str(corr_wr)
+                if uncorr_packed is not None:
+                    uncorr_rd, uncorr_wr = decode_gddr_uncorr_errs(
+                        uncorr_packed, channel
+                    )
+                    ch["uncorr_rd"] = str(uncorr_rd)
+                    ch["uncorr_wr"] = str(uncorr_wr)
+            gddr["channels"].append(ch)
+        return gddr
+
+    if is_wormhole:
+        dram_status = parse_telem_hex(smbus_telem, "DDR_STATUS")
+        if dram_status is not None:
+            dram_status &= 0xFFFFFF
+        for channel in range(WH_GDDR_CHANNELS):
+            ch = _gddr_channel_na(channel, enabled=True)
+            if dram_status is not None:
+                ch["training"] = decode_wh_gddr_channel_training(dram_status, channel)
+            gddr["channels"].append(ch)
+        return gddr
+
+    return gddr
 
 
 def p100_dram_training_passed(dram_status: int) -> bool:


### PR DESCRIPTION
Decode packed GDDR status, die temperatures, and EDC errors into a dedicated gddr_telemetry object so the GUI and snapshots can show per-channel DRAM health next to the existing Telemetry tab.