### PR TITLE
Source Latest Releases from tt-sw-manifest golden pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,35 @@ Host processes currently holding open Tenstorrent device handles. Updated about 
 | Device | Logical device index the process is using. |
 | Command | Process command line (or executable name) as reported by the host. |
 
+### Tested Versions
+
+The sidebar box lists the version of each component in the Tenstorrent software
+stack that we have validated. These are **not** each project's newest release.
+They come from [`golden.json`][golden] in the latest [tt-sw-manifest][manifest]
+release: the set of versions that CI installs and exercises together as one
+stack. Renovate opens a PR there as components publish new releases, and a pin
+only moves once the full validation suite passes on the combination, so the
+newest release of a component and its tested version can differ. This is the
+same set that [tt-installer][installer] installs by default.
+
+Where TT-SMI can determine what is installed on the host (tt-kmd through sysfs,
+tt-smi and tt-flash through their CLIs), the row is marked:
+
+| Marker | Meaning |
+|--------|---------|
+| `✓` | Matches the tested version. |
+| `↑` | Older than the tested version, shown as `installed → tested`. |
+| `▲` | Newer than the tested version. Not an error: the host is running ahead of the validated stack, so this particular combination has not been tested together. |
+
+Rows with no marker are informational, since TT-SMI has no way to tell what is
+installed for them.
+
+Run `tt-smi --offline` to skip the fetch and hide the box.
+
+[golden]: https://github.com/tenstorrent/tt-sw-manifest/blob/main/golden.json
+[installer]: https://github.com/tenstorrent/tt-installer
+[manifest]: https://github.com/tenstorrent/tt-sw-manifest
+
 ## Listing devices
 
 Use **`tt-smi -ls`** or **`tt-smi --list`** to print a table of Tenstorrent devices and exit (no GUI). This is the easiest way to see **UMD Chip ID**, **PCI BDF**, and **`/dev/tenstorrent/<n>`** (shown as **PCI Dev ID**) for each board—use these values with `tt-smi -r` as described in [Resets](#resets).

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -98,30 +98,37 @@ class LatestReleasesBox(Container):
         self.refresh()
 
     def _row_status(
-        self, spec_name: str, latest: Optional[str]
+        self, spec_name: str, golden: Optional[str]
     ) -> Tuple[str, Optional[Style], str, Optional[Style]]:
         """Return (glyph, glyph_style, value_text, value_style) for one row.
 
-        The value column shows "installed → latest" for the outdated case so
-        users see exactly what bump is available; everything else just shows
-        the latest version (or "—" if it's unknown).
+        Once both versions are known there are three states. Behind golden
+        shows "installed → golden" so the available bump is explicit. Ahead of
+        golden shows the installed version: running past the validated stack is
+        expected on dev hosts, so it's flagged rather than treated as an error,
+        and the row must not print a pin the host isn't actually on. A match
+        shows the pin itself.
         """
         muted = Style(color="grey50")
         installed = self._installed.get(spec_name)
         if installed is None:
             # Not checkable on this host, or not installed: no status glyph.
-            if latest is None:
+            if golden is None:
                 return ("", None, "—", muted)
-            return ("", None, latest, None)
+            return ("", None, golden, None)
 
-        if latest is None:
-            # We have installed but couldn't fetch latest.
+        if golden is None:
+            # We have installed but couldn't fetch the golden manifest.
             return ("", None, "—", muted)
 
-        if version_tuple(installed) >= version_tuple(latest):
-            return ("✓", Style(color="green"), latest, None)
+        if version_tuple(installed) > version_tuple(golden):
+            ahead = Style(color="cyan")
+            return ("▲", ahead, installed, ahead)
 
-        return ("↑", Style(color="yellow"), f"{installed} → {latest}", Style(color="yellow"))
+        if version_tuple(installed) == version_tuple(golden):
+            return ("✓", Style(color="green"), golden, None)
+
+        return ("↑", Style(color="yellow"), f"{installed} → {golden}", Style(color="yellow"))
 
     def _render_versions(self) -> Text:
         text = Text()

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -147,7 +147,7 @@ class LatestReleasesBox(Container):
 
     def _render_error(self) -> Text:
         return Text(
-            "Failed to fetch latest releases.\nCheck your network connection.",
+            "Failed to fetch tested versions.\nCheck your network connection.",
             style=Style(color="red"),
         )
 
@@ -230,7 +230,7 @@ class TTSMI(App):
                 if not self.offline:
                     yield LatestReleasesBox(
                         id="latest_releases",
-                        title="Latest Releases",
+                        title="Tested Versions",
                     )
             with TabbedContent(
                 "Information (1)", "Telemetry (2)", "FW Version (3)", "Processes (4)", id="tab_container"

--- a/tt_smi/frontend.py
+++ b/tt_smi/frontend.py
@@ -39,11 +39,12 @@ from .utils import hex_to_semver_eth, hex_to_semver_m3_fw
 
 
 class LatestReleasesBox(Container):
-    """Sidebar box showing the latest published version of each tt-stack package.
+    """Sidebar box showing the golden-pinned version of each tt-stack package.
 
-    Renders a ProgressBar while fetches are in-flight, then swaps to a list of
-    versions. If every fetch fails (e.g. no internet), the list stays empty
-    and the box just shows its border + title.
+    Versions come from the tt-sw-manifest golden stack, not from each repo's
+    newest upstream release. Renders a ProgressBar while the fetch is
+    in-flight, then swaps to a list of versions. If the fetch fails (e.g. no
+    internet), the list stays empty and the box just shows its border + title.
     """
 
     def __init__(self, id: str, title: str) -> None:
@@ -284,7 +285,7 @@ class TTSMI(App):
             )
 
     def fetch_latest_releases(self) -> None:
-        """Worker: fetch latest GitHub release tags and push them to the box."""
+        """Worker: fetch the golden version pins and push them to the box."""
         try:
             box = self.query_one("#latest_releases", LatestReleasesBox)
         except NoMatches:

--- a/tt_smi/latest_releases.py
+++ b/tt_smi/latest_releases.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Fetches the latest published GitHub release tag for tt-stack packages.
+"""Fetches the golden version pins for tt-stack packages.
 
-Each package has a tag pattern with a named "version" group; only releases
-whose tag matches the pattern are considered. This mirrors the renovate
-filter rules used by infra (allowedVersions / extractVersion).
+The source of truth is `golden.json` from the latest tt-sw-manifest release:
+a set of component versions that have been validated together as one stack.
+This is deliberately *not* each repo's newest upstream release, which may not
+yet be approved. Each package maps to one pin field in that manifest.
 """
 
 import json
@@ -14,7 +15,6 @@ import shutil
 import subprocess
 import urllib.error
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -22,8 +22,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 @dataclass(frozen=True)
 class ReleaseSpec:
     name: str
-    repo: str
-    tag_pattern: "re.Pattern[str]"
+    pin: str
     # cli=None means there's no PATH-based check for this package (firmware,
     # metalium image, etc.). tt-kmd has no CLI but is checkable via sysfs, so
     # we leave cli=None and special-case it in get_installed_version.
@@ -31,13 +30,15 @@ class ReleaseSpec:
 
 
 RELEASE_SPECS: List[ReleaseSpec] = [
-    ReleaseSpec("tt-kmd",             "tenstorrent/tt-kmd",             re.compile(r"^ttkmd-?(?P<version>\d+\.\d+\.\d+)$")),
-    ReleaseSpec("tt-smi",             "tenstorrent/tt-smi",             re.compile(r"^v?(?P<version>\d+\.\d+\.\d+)$"),       cli="tt-smi"),
-    ReleaseSpec("tt-flash",           "tenstorrent/tt-flash",           re.compile(r"^v?(?P<version>\d+\.\d+\.\d+)$"),       cli="tt-flash"),
-    ReleaseSpec("tt-system-firmware", "tenstorrent/tt-system-firmware", re.compile(r"^v?(?P<version>19\.\d+\.\d+)$")),
-    ReleaseSpec("tt-metal",           "tenstorrent/tt-metal",           re.compile(r"^v?(?P<version>0\.\d+\.\d+)$")),
-    ReleaseSpec("tt-installer",       "tenstorrent/tt-installer",       re.compile(r"^v?(?P<version>\d+\.\d+\.\d+)$")),
+    ReleaseSpec("tt-kmd",             "kmd"),
+    ReleaseSpec("tt-smi",             "smi",            cli="tt-smi"),
+    ReleaseSpec("tt-flash",           "flash",          cli="tt-flash"),
+    ReleaseSpec("tt-system-firmware", "firmware"),
+    ReleaseSpec("tt-metal",           "metal-version"),
+    ReleaseSpec("tt-installer",       "installer"),
 ]
+
+GOLDEN_MANIFEST_URL = "https://github.com/tenstorrent/tt-sw-manifest/releases/latest/download/golden.json"
 
 
 def is_checkable(spec: ReleaseSpec) -> bool:
@@ -105,52 +106,36 @@ def version_tuple(v: str) -> Tuple[int, ...]:
     return tuple(parts)
 
 
-def _fetch_latest_matching(spec: ReleaseSpec, timeout: float) -> Optional[str]:
-    """Return the version string of the newest release matching spec, or None."""
-    url = f"https://api.github.com/repos/{spec.repo}/releases?per_page=100"
+def _fetch_golden(timeout: float) -> Optional[Dict[str, str]]:
+    """Return the golden manifest pins, or None if the fetch/parse failed."""
     req = urllib.request.Request(
-        url,
+        GOLDEN_MANIFEST_URL,
         headers={
-            "Accept": "application/vnd.github+json",
+            "Accept": "application/json",
             "User-Agent": "tt-smi",
         },
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            releases = json.loads(resp.read())
+            manifest = json.loads(resp.read())
     except (urllib.error.URLError, OSError, json.JSONDecodeError, ValueError):
         return None
+    return manifest if isinstance(manifest, dict) else None
 
-    for release in releases:
-        if release.get("draft") or release.get("prerelease"):
-            continue
-        m = spec.tag_pattern.match(release.get("tag_name", ""))
-        if m:
-            return m.group("version")
-    return None
+
+def _pinned_version(manifest: Dict[str, str], spec: ReleaseSpec) -> Optional[str]:
+    """Pull one spec's version out of the manifest, normalized to bare semver.
+
+    Pins are written as plain versions except metal-version, which carries the
+    upstream "v" tag prefix.
+    """
+    pinned = manifest.get(spec.pin)
+    if not isinstance(pinned, str):
+        return None
+    return pinned.removeprefix("v") or None
 
 
 DEFAULT_MAX_ATTEMPTS = 3
-
-
-def _fetch_batch(
-    specs: List[ReleaseSpec], timeout: float
-) -> Dict[str, Optional[str]]:
-    """Run one parallel pass over `specs`. Returns {name: version_or_None}."""
-    results: Dict[str, Optional[str]] = {}
-    if not specs:
-        return results
-    with ThreadPoolExecutor(max_workers=len(specs)) as pool:
-        futures = {
-            pool.submit(_fetch_latest_matching, spec, timeout): spec for spec in specs
-        }
-        for fut in as_completed(futures):
-            spec = futures[fut]
-            try:
-                results[spec.name] = fut.result()
-            except Exception:
-                results[spec.name] = None
-    return results
 
 
 def fetch_all(
@@ -159,16 +144,15 @@ def fetch_all(
     on_attempt: Optional[Callable[[int], None]] = None,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
 ) -> Dict[str, Optional[str]]:
-    """Fetch latest versions for every spec, retrying any that come back None.
+    """Fetch the golden pin for every spec, retrying the manifest on failure.
 
-    Each attempt runs the remaining failed specs in parallel. `on_done` fires
-    exactly once per spec, when its version is known (success) or has exhausted
-    all attempts (final None). `on_attempt(n)` fires at the start of attempts
-    where n > 1 so callers can surface a retry indicator; it is not called for
-    the first attempt.
+    All pins come from a single manifest, so one fetch resolves every spec.
+    `on_done` fires exactly once per spec, with its pinned version or None if
+    the manifest could not be fetched (or has no pin for it). `on_attempt(n)`
+    fires at the start of attempts where n > 1 so callers can surface a retry
+    indicator; it is not called for the first attempt.
     """
-    pending = list(RELEASE_SPECS)
-    final: Dict[str, Optional[str]] = {}
+    manifest = None
     for attempt in range(1, max_attempts + 1):
         if attempt > 1 and on_attempt is not None:
             try:
@@ -176,21 +160,17 @@ def fetch_all(
             except Exception:
                 pass
 
-        round_results = _fetch_batch(pending, timeout)
-
-        next_pending: List[ReleaseSpec] = []
-        for spec in pending:
-            version = round_results.get(spec.name)
-            if version is not None or attempt == max_attempts:
-                final[spec.name] = version
-                if on_done is not None:
-                    try:
-                        on_done(spec, version)
-                    except Exception:
-                        pass
-            else:
-                next_pending.append(spec)
-        pending = next_pending
-        if not pending:
+        manifest = _fetch_golden(timeout)
+        if manifest is not None:
             break
+
+    final: Dict[str, Optional[str]] = {}
+    for spec in RELEASE_SPECS:
+        version = _pinned_version(manifest, spec) if manifest is not None else None
+        final[spec.name] = version
+        if on_done is not None:
+            try:
+                on_done(spec, version)
+            except Exception:
+                pass
     return final

--- a/tt_smi/tt_smi.py
+++ b/tt_smi/tt_smi.py
@@ -86,7 +86,7 @@ def parse_args():
         "--offline",
         default=False,
         action="store_true",
-        help="Do not access the network; hides the Latest Releases box",
+        help="Do not access the network; hides the Tested Versions box",
     )
     parser.add_argument(
         "-r",


### PR DESCRIPTION
Fixes #252.

The box fetched each repo's newest published GitHub release, which conflicts with the golden stack. A host installed via tt-installer against tt-sw-manifest v1.0.0 sits on KMD 2.10.0 and was flagged as outdated, even though that is the latest *approved* version.

This switches the source of truth to `golden.json` from the latest [tt-sw-manifest](https://github.com/tenstorrent/tt-sw-manifest) release, so the box reports what has been validated together as a stack rather than what happens to be newest upstream.

## Changes

**Source the versions from the golden manifest**

- `ReleaseSpec` drops `repo`/`tag_pattern` for a single `pin` field naming the `golden.json` key (`kmd`, `smi`, `flash`, `firmware`, `metal-version`, `installer`). The per-repo tag regexes that mirrored the renovate filter rules are no longer needed; the manifest already holds the approved version.
- All pins come from one document, so the six-way parallel fan-out over the GitHub releases API collapses to a single fetch and the `ThreadPoolExecutor` pass goes away. Retries now re-fetch the manifest.
- `metal-version` is the one pin carrying an upstream `v` tag prefix; it is normalized to bare semver alongside the others.

`fetch_all` keeps its signature, so the progress bar and retry indicator are unchanged.

**Flag packages running ahead of the pin**

Sourcing from the manifest makes "installed is newer than the reference" a normal state, which the old two-state row handled badly. `>=` fell into the match branch, and that branch prints the *reference* version, so a syseng box on KMD 2.11.0 had the row claim 2.10.0. The row is now three states:

| State | Row | Colour |
|-------|-----|--------|
| Behind | `↑ tt-kmd : 2.9.0 → 2.10.0` | yellow |
| Matches | `✓ tt-kmd : 2.10.0` | green |
| Ahead | `▲ tt-kmd : 2.11.0` | cyan |

Running past the validated stack is expected on dev hosts, so it is flagged rather than treated as an error, and no row prints a version the host is not actually on.

**Rename the box to "Tested Versions" and document it** (review feedback)

"Latest Releases" still read as "newest upstream", which is the confusion this PR set out to remove. Retitles the box and the two other user-visible strings that named it (the fetch-failure message and the `--offline` help text), and adds a README section under GUI covering where the versions come from, what each marker means, and why a row can read newer than the tested version.

## Notes

- Displayed packages are unchanged. `golden.json` also pins `sfpi` and `hugepages`, which the box does not show; happy to add rows for them if that is wanted.
- Internal identifiers (`latest_releases.py`, `LatestReleasesBox`, the `#latest_releases` CSS selector and ids) still use the old name. Kept out of this PR to hold the diff down; say the word and I will rename them to match.
- `images/tt_smi.png` still shows the old box title.

## Testing

Verified on a P150 (`yyz-syseng-01`).

Against the live manifest (`v1.0.0`), all six rows resolve: kmd 2.10.0, smi 6.1.0, flash 3.10.0, firmware 19.13.1, metal 0.75.0 (from `v0.75.0`), installer 3.5.2. The scenario in #252, KMD 2.10.0 installed, now renders `✓` instead of `↑`.

Row states verified against the real `_row_status` for: ahead, exact match, behind, not-installed, and manifest-fetch-failed.

Failure path exercised with an unreachable host: three attempts, `on_attempt` firing at 2 and 3, all-`None` result falling through to the "Failed to fetch" render.
